### PR TITLE
22-Persisting-an-OGCPoint-with-same-lat-and-lon-value-is-not-properly-read-back

### DIFF
--- a/src/OmniBase-Tests/ODBSerializerBugsTest.class.st
+++ b/src/OmniBase-Tests/ODBSerializerBugsTest.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : #ODBSerializerBugsTest,
+	#superclass : #TestCase,
+	#category : #'OmniBase-Tests'
+}
+
+{ #category : #tests }
+ODBSerializerBugsTest >> testSerializationSmallFloat64Two [
+	| object serialized materialized |
+	
+	"try to serialize an object that references twice the same small floats"
+	object := {1.11 . 1.11}.
+
+	serialized := ODBSerializer serializeToBytes: object.
+	materialized := ODBDeserializer deserializeFromBytes: serialized.
+	self assert: materialized equals: object.
+	
+	"We changed serialization fixing https://github.com/ApptiveGrid/MoniBase/issues/22
+	This checks that we can load the old serialized Floats after the change"
+	
+	materialized := ODBDeserializer 
+		deserializeFromBytes: #[0 0 1 0 0 0 47 158 138 142 255 7 134 215 199 194 11].
+	self assert: materialized equals: object first.
+]

--- a/src/OmniBase/SmallFloat64.extension.st
+++ b/src/OmniBase/SmallFloat64.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : #SmallFloat64 }
 
 { #category : #'*OmniBase' }
-SmallFloat64 >> odbBasicSerialize: serializer [ 
+SmallFloat64 >> odbSerialize: serializer [ 
 	serializer stream
 		putByte: 47;
 		putInteger: (self at: 1);


### PR DESCRIPTION
This is a minimal change to fix Small Float Serialization.

- add testSerializationSmallFloat64Two. This tests the scenario that failed *and* tests that the old serialized Floats can be still read
- make that SmallFloat64 implements #odbSerialize:, not odbBasicSerialize:

This fix follows the style used in the rest of the code. We should open an issue to refactor and document #odbBasicSerialize:

fixes #22

