### PR TITLE
add #packageNamesUnderTest to simplify code coverage tool usage

### DIFF
--- a/src/OmniBase-Tests/OmniBaseTest.class.st
+++ b/src/OmniBase-Tests/OmniBaseTest.class.st
@@ -5,6 +5,11 @@ Class {
 }
 
 { #category : #accessing }
+OmniBaseTest class >> packageNamesUnderTest [
+	^ #(OmniBase)
+]
+
+{ #category : #accessing }
 OmniBaseTest >> collection [
 
 	| coll |


### PR DESCRIPTION
This will remove the need to select the package under test when running tests with coverage analysis