### PR TITLE
Remove-unsent-inspectorMethods

### DIFF
--- a/src/OmniBase/ODBBTreeMultiValueDictionary.class.st
+++ b/src/OmniBase/ODBBTreeMultiValueDictionary.class.st
@@ -1,3 +1,6 @@
+"
+This class is not yet implemented.
+"
 Class {
 	#name : #ODBBTreeMultiValueDictionary,
 	#superclass : #ODBBTreeIndexDictionary,
@@ -8,13 +11,6 @@ Class {
 	],
 	#category : #'OmniBase-Transaction'
 }
-
-{ #category : #public }
-ODBBTreeMultiValueDictionary >> COMMENT [
-	"This class is not yet implemented."
-
-	
-]
 
 { #category : #public }
 ODBBTreeMultiValueDictionary >> add: anAssociation [ 

--- a/src/OmniBase/ODBExpiredProxyObject.class.st
+++ b/src/OmniBase/ODBExpiredProxyObject.class.st
@@ -34,13 +34,6 @@ ODBExpiredProxyObject >> becomeForward: otherObject [
 ]
 
 { #category : #public }
-ODBExpiredProxyObject >> defaultLabelForInspector [
-	"Answer the default label to be used for an Inspector window on the receiver."
-
-	^ self class name
-]
-
-{ #category : #public }
 ODBExpiredProxyObject >> doesNotUnderstand: aMessage [
 	
 	| currentTransaction freshTarget |
@@ -74,14 +67,6 @@ ODBExpiredProxyObject >> halt [
 ODBExpiredProxyObject >> inspect [
 	"Create and schedule an Inspector in which the user can examine the receiver's variables."
 	Smalltalk tools inspect: self
-]
-
-{ #category : #public }
-ODBExpiredProxyObject >> inspectorClass [
-	"Answer the class of the inspector to be used on the receiver.  Called by inspect; 
-	use basicInspect to get a normal (less useful) type of inspector."
-
-	^ Smalltalk tools inspector
 ]
 
 { #category : #public }

--- a/src/OmniBase/ODBReference.class.st
+++ b/src/OmniBase/ODBReference.class.st
@@ -18,13 +18,6 @@ ODBReference >> == anObject [
 	self primitiveFailed
 ]
 
-{ #category : #public }
-ODBReference >> defaultLabelForInspector [
-	"Answer the default label to be used for an Inspector window on the receiver."
-
-	^ self class name
-]
-
 { #category : #accessing }
 ODBReference >> demandLoader [
 
@@ -53,14 +46,6 @@ ODBReference >> halt [
 ODBReference >> inspect [
 	"Create and schedule an Inspector in which the user can examine the receiver's variables."
 	Smalltalk tools inspector inspect: self
-]
-
-{ #category : #public }
-ODBReference >> inspectorClass [
-	"Answer the class of the inspector to be used on the receiver.  Called by inspect; 
-	use basicInspect to get a normal (less useful) type of inspector."
-
-	^ Smalltalk tools inspector
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This PR removes the methods

- #defaultLabelForInspector and #inspectorClass. Not used anymore, no senders
- moved the content from a method COMMENT to the class comment of the class ODBBTreeMultiValueDictionary

