### PR TITLE
Deadcode clean  #odbBasicSerialize:

### DIFF
--- a/src/OmniBase/Character.extension.st
+++ b/src/OmniBase/Character.extension.st
@@ -1,16 +1,6 @@
 Extension { #name : #Character }
 
 { #category : #'*omnibase' }
-Character >> odbBasicSerialize: serializer [
-
-	self asInteger < 256 ifTrue: [
-		serializer stream putByte: 13; putChar: self.
-		^self
-	].
-	serializer stream putByte: 29; putWord: self asInteger
-]
-
-{ #category : #'*omnibase' }
 Character class >> odbDeserialize: deserializer [
 
 	^deserializer stream getChar

--- a/src/OmniBase/False.extension.st
+++ b/src/OmniBase/False.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : #False }
 
 { #category : #'*omnibase' }
-False >> odbBasicSerialize: serializer [
-
-	serializer stream putByte: 16
-]
-
-{ #category : #'*omnibase' }
 False >> odbObjectID [
 
 	^ODBObjectID containerID: 0 index: 3

--- a/src/OmniBase/Fraction.extension.st
+++ b/src/OmniBase/Fraction.extension.st
@@ -1,15 +1,6 @@
 Extension { #name : #Fraction }
 
 { #category : #'*omnibase' }
-Fraction >> odbBasicSerialize: serializer [
-
-	serializer stream
-		putByte: 39;
-		putInteger: numerator;
-		putInteger: denominator
-]
-
-{ #category : #'*omnibase' }
 Fraction class >> odbDeserialize: deserializer [
 
 	^self numerator: deserializer stream getInteger

--- a/src/OmniBase/Integer.extension.st
+++ b/src/OmniBase/Integer.extension.st
@@ -25,17 +25,6 @@ Integer >> asBtreeKeyOfSize: keySize [
 ]
 
 { #category : #'*omnibase' }
-Integer >> odbBasicSerialize: serializer [
-
-	self < 0 ifTrue: [
-		self > -4 ifTrue: [ ^serializer stream putByte: self + 70 ].
-		^serializer stream putByte: 12; putPositiveInteger: 0 - self.
-	].
-	self < 17 ifTrue: [ ^serializer stream putByte: self + 50 ].
-	serializer stream putByte: 11; putPositiveInteger: self
-]
-
-{ #category : #'*omnibase' }
 Integer >> odbSerialize: serializer [
 
 	self < 0 ifTrue: [

--- a/src/OmniBase/ODBExpiredProxyObject.class.st
+++ b/src/OmniBase/ODBExpiredProxyObject.class.st
@@ -102,12 +102,6 @@ ODBExpiredProxyObject >> isODBPersistent [
 ]
 
 { #category : #public }
-ODBExpiredProxyObject >> odbBasicSerialize: serializer [ 
-	OmniBase 
-		signalError: 'This object can not be serialized. The transaction in which this proxy was loaded is already aborted.'
-]
-
-{ #category : #public }
 ODBExpiredProxyObject >> odbSerialize: serializer [ 
 	OmniBase 
 		signalError: 'This object can not be serialized. The transaction in which this proxy was loaded is already aborted.'

--- a/src/OmniBase/ODBTransaction.class.st
+++ b/src/OmniBase/ODBTransaction.class.st
@@ -263,12 +263,6 @@ ODBTransaction >> objectHolderAt: objectID [
 ]
 
 { #category : #'private/unclassified' }
-ODBTransaction >> odbBasicSerialize: serializer [
-
-	serializer stream putByte: 84
-]
-
-{ #category : #'private/unclassified' }
 ODBTransaction >> odbObjectID [
 
     ^ODBObjectID containerID: 0 index: 1000

--- a/src/OmniBase/ProcessorScheduler.extension.st
+++ b/src/OmniBase/ProcessorScheduler.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : #ProcessorScheduler }
 
 { #category : #'*omnibase' }
-ProcessorScheduler >> odbBasicSerialize: serializer [
-
-	serializer stream putByte: 22
-]
-
-{ #category : #'*omnibase' }
 ProcessorScheduler >> odbSerialize: serializer [
 
 	serializer stream putByte: 22

--- a/src/OmniBase/Symbol.extension.st
+++ b/src/OmniBase/Symbol.extension.st
@@ -1,15 +1,6 @@
 Extension { #name : #Symbol }
 
 { #category : #'*omnibase' }
-Symbol >> odbBasicSerialize: serializer [
-
-	serializer stream
-		putByte: 18;
-		putPositiveInteger: self size;
-		putBytesFrom: self asByteArray len: self size
-]
-
-{ #category : #'*omnibase' }
 Symbol class >> odbDeserialize: deserializer [
 
 	| bytes len |

--- a/src/OmniBase/SystemDictionary.extension.st
+++ b/src/OmniBase/SystemDictionary.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : #SystemDictionary }
 
 { #category : #'*omnibase' }
-SystemDictionary >> odbBasicSerialize: serializer [
-
-	serializer stream putByte: 19
-]
-
-{ #category : #'*omnibase' }
 SystemDictionary >> odbSerialize: serializer [
 
 	serializer stream putByte: 19

--- a/src/OmniBase/True.extension.st
+++ b/src/OmniBase/True.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : #True }
 
 { #category : #'*omnibase' }
-True >> odbBasicSerialize: serializer [
-
-	serializer stream putByte: 15
-]
-
-{ #category : #'*omnibase' }
 True >> odbObjectID [
 
 	^ODBObjectID containerID: 0 index: 2

--- a/src/OmniBase/UndefinedObject.extension.st
+++ b/src/OmniBase/UndefinedObject.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : #UndefinedObject }
 
 { #category : #'*omnibase' }
-UndefinedObject >> odbBasicSerialize: serializer [
-
-	serializer stream putByte: 14
-]
-
-{ #category : #'*omnibase' }
 UndefinedObject >> odbDeserialize: deserializer [
 
 	deserializer loadError


### PR DESCRIPTION
This PR removes all the #odbBasicSerialize: methods where we have the… exact same implementation in odbSerialize.