### PR TITLE
Trivial Cleanup: categorize #initialize methods

### DIFF
--- a/src/OmniBase/ODBBTreeDictionary.class.st
+++ b/src/OmniBase/ODBBTreeDictionary.class.st
@@ -148,9 +148,8 @@ ODBBTreeDictionary >> databaseObjectClass [
 	^ODBDBBTreeDictionary
 ]
 
-{ #category : #private }
+{ #category : #initialization }
 ODBBTreeDictionary >> initialize [
-        "Private - Initialize receiver."
 
     super initialize.
     initialSize := 0.

--- a/src/OmniBase/ODBBTreeIdentityDictionary.class.st
+++ b/src/OmniBase/ODBBTreeIdentityDictionary.class.st
@@ -67,7 +67,7 @@ ODBBTreeIdentityDictionary >> includesKey: aKey [
 				ifFalse: [super includesKey: oid]]
 ]
 
-{ #category : #private }
+{ #category : #initialization }
 ODBBTreeIdentityDictionary >> initialize [
 	super initialize.
 	keySize := ODBObjectID sizeInBytes.

--- a/src/OmniBase/ODBBTreeIndexDictionary.class.st
+++ b/src/OmniBase/ODBBTreeIndexDictionary.class.st
@@ -351,9 +351,8 @@ ODBBTreeIndexDictionary >> includesKey: aKey [
 	^value isRemoved not
 ]
 
-{ #category : #private }
+{ #category : #initialization }
 ODBBTreeIndexDictionary >> initialize [
-	"Private - Initialize receiver."
 
 	super initialize.
 	keySize := 32

--- a/src/OmniBase/ODBBTreeIntegerIndexDictionary.class.st
+++ b/src/OmniBase/ODBBTreeIntegerIndexDictionary.class.st
@@ -19,9 +19,8 @@ ODBBTreeIntegerIndexDictionary >> databaseObjectClass [
 	^ODBDBBTreeIntegerIndexDictionary
 ]
 
-{ #category : #private }
+{ #category : #initialization }
 ODBBTreeIntegerIndexDictionary >> initialize [
-	"Private - Initialize receiver."
 
 	super initialize.
 	keySize := 4

--- a/src/OmniBase/ODBBTreeIterator.class.st
+++ b/src/OmniBase/ODBBTreeIterator.class.st
@@ -191,14 +191,13 @@ ODBBTreeIterator >> goToAndGetCurrentAt: aKey [
 	^result
 ]
 
-{ #category : #'private/initialization' }
+{ #category : #initialization }
 ODBBTreeIterator >> initialize [
-		"Private - Initialize receiver."
 
 	searchPath := Array new: 20.
 	searchPathHeight := 0.
 	rootPagePosition := self headerLength + ODBSizeHolder sizeInBytes + 4.
-	mutex := Semaphore forMutualExclusion.
+	mutex := Semaphore forMutualExclusion
 ]
 
 { #category : #private }

--- a/src/OmniBase/ODBBTreeMultiValueDictionary.class.st
+++ b/src/OmniBase/ODBBTreeMultiValueDictionary.class.st
@@ -33,9 +33,8 @@ ODBBTreeMultiValueDictionary >> at: aKey put: anObject [
 ODBBTreeMultiValueDictionary >> atKey: aKey add: anObject [
 ]
 
-{ #category : #private }
+{ #category : #initialization }
 ODBBTreeMultiValueDictionary >> initialize [
-	"Private - Initialize receiver."
 
 	super initialize.
 	initialSize := 0.

--- a/src/OmniBase/ODBChange.class.st
+++ b/src/OmniBase/ODBChange.class.st
@@ -31,7 +31,7 @@ ODBChange >> commit [
 ODBChange >> committed [
 ]
 
-{ #category : #private }
+{ #category : #initialization }
 ODBChange >> initialize [
 	
 ]

--- a/src/OmniBase/ODBChangesPackage.class.st
+++ b/src/OmniBase/ODBChangesPackage.class.st
@@ -44,7 +44,7 @@ ODBChangesPackage >> committed [
     changes do: [:each | each committed]
 ]
 
-{ #category : #private }
+{ #category : #initialization }
 ODBChangesPackage >> initialize [
 	changes := (SortedCollection new: 300) sortBlock: self
 ]

--- a/src/OmniBase/ODBClassInfoFile.class.st
+++ b/src/OmniBase/ODBClassInfoFile.class.st
@@ -25,9 +25,8 @@ OmniBase 1.0, David Gorisek (c) 1998
 '
 ]
 
-{ #category : #public }
+{ #category : #initialization }
 ODBClassInfoFile >> initialize [
-	"Private - Initialize receiver."
 
 	super initialize.
 	keyLength := 128.

--- a/src/OmniBase/ODBClassManager.class.st
+++ b/src/OmniBase/ODBClassManager.class.st
@@ -161,7 +161,7 @@ ODBClassManager >> infoFileName [
 	^ODBFileStream pathSeparatorString , 'omnibase.odl'
 ]
 
-{ #category : #private }
+{ #category : #initialization }
 ODBClassManager >> initialize [
 	classes := OrderedCollection new.
 	names := ODBIdentityDictionary new

--- a/src/OmniBase/ODBClient.class.st
+++ b/src/OmniBase/ODBClient.class.st
@@ -31,7 +31,7 @@ ODBClient >> description [
     ^clientFile clientDescription
 ]
 
-{ #category : #private }
+{ #category : #initialization }
 ODBClient >> initialize [
 
     transactions := OrderedCollection new.

--- a/src/OmniBase/ODBClientTable.class.st
+++ b/src/OmniBase/ODBClientTable.class.st
@@ -82,7 +82,7 @@ ODBClientTable >> globalUnlock [
 	[self globalLockClientID: 0] ensure: [self unlockTable]
 ]
 
-{ #category : #public }
+{ #category : #initialization }
 ODBClientTable >> initialize [
 	table := ByteArray new: self class maxClients + 1
 ]

--- a/src/OmniBase/ODBContainer.class.st
+++ b/src/OmniBase/ODBContainer.class.st
@@ -197,7 +197,7 @@ ODBContainer >> initHolders: holders [
     indexFile addHolders: holders
 ]
 
-{ #category : #private }
+{ #category : #initialization }
 ODBContainer >> initialize [
 	dbFiles := ODBWeakValueIdentityDictionary new.
 	dbFilesMutex := Semaphore forMutualExclusion.

--- a/src/OmniBase/ODBContainerInfoFile.class.st
+++ b/src/OmniBase/ODBContainerInfoFile.class.st
@@ -38,9 +38,8 @@ OmniBase 1.0, David Gorisek (c) 1998
 '
 ]
 
-{ #category : #'private/initialization' }
+{ #category : #initialization }
 ODBContainerInfoFile >> initialize [
-        "Private - Initialize receiver."
 
     super initialize.
     keyLength := 20.

--- a/src/OmniBase/ODBDatabaseObject.class.st
+++ b/src/OmniBase/ODBDatabaseObject.class.st
@@ -37,9 +37,9 @@ ODBDatabaseObject class >> hasExternalFiles [
 	^false
 ]
 
-{ #category : #private }
+{ #category : #'class initialization' }
 ODBDatabaseObject class >> initialize [
-	"Private - Initialize ClassIDs array used to convert classID to appropriate class."
+	"Initialize ClassIDs array used to convert classID to appropriate class"
 
 	| dict maxID |
 	dict := IdentityDictionary new.

--- a/src/OmniBase/ODBIDTable.class.st
+++ b/src/OmniBase/ODBIDTable.class.st
@@ -69,7 +69,7 @@ ODBIDTable >> indexesAndValuesDo: aBlock [
 	1 to: self getLastID do: [:index | aBlock value: index value: (self at: index)]
 ]
 
-{ #category : #'private/initialization' }
+{ #category : #initialization }
 ODBIDTable >> initialize [
 
     lastID := 0

--- a/src/OmniBase/ODBLocalClient.class.st
+++ b/src/OmniBase/ODBLocalClient.class.st
@@ -69,13 +69,14 @@ ODBLocalClient >> globalUnlock [
     ^true
 ]
 
-{ #category : #'private/initialization' }
+{ #category : #initialization }
 ODBLocalClient >> initialize [
-        "Private - Initialize receiver."
 
-    transactions := IdentitySet new: 20.
-    transactionFiles := OrderedCollection new.
-    hasGlobalLock := false.
+	self flag: #Cleanup.
+	"should do super initialize, but super uses OrderedCollection for transactions"
+	transactions := IdentitySet new: 20.
+	transactionFiles := OrderedCollection new.
+	hasGlobalLock := false
 ]
 
 { #category : #'public/unclassified' }

--- a/src/OmniBase/ODBLocalTransaction.class.st
+++ b/src/OmniBase/ODBLocalTransaction.class.st
@@ -99,7 +99,6 @@ ODBLocalTransaction >> committed [
 
 { #category : #initialization }
 ODBLocalTransaction >> initialize [
-        "Private - Initialize receiver."
 
     super initialize.
     newObjects := Array new: 16

--- a/src/OmniBase/ODBMemoryWriteStream.class.st
+++ b/src/OmniBase/ODBMemoryWriteStream.class.st
@@ -69,7 +69,7 @@ ODBMemoryWriteStream >> asStringObject [
 	^string
 ]
 
-{ #category : #private }
+{ #category : #initialization }
 ODBMemoryWriteStream >> initialize [
 
     collections := OrderedCollection new.

--- a/src/OmniBase/ODBObjectHolder.class.st
+++ b/src/OmniBase/ODBObjectHolder.class.st
@@ -63,7 +63,6 @@ ODBObjectHolder >> getObject [
 
 { #category : #initialization }
 ODBObjectHolder >> initialize [
-        "Private - Initialize receiver."
 
     oldVersion := false
 ]

--- a/src/OmniBase/ODBObjectIDDictionary.class.st
+++ b/src/OmniBase/ODBObjectIDDictionary.class.st
@@ -38,7 +38,7 @@ ODBObjectIDDictionary >> at: objectID put: anObject [
 	^dict at: objectID index put: anObject
 ]
 
-{ #category : #'private/initialization' }
+{ #category : #initialization }
 ODBObjectIDDictionary >> initialize [
 
     dictionaries := Array new: 255

--- a/src/OmniBase/ODBObjectIndexFile.class.st
+++ b/src/OmniBase/ODBObjectIndexFile.class.st
@@ -168,7 +168,7 @@ ODBObjectIndexFile >> indexesAndValuesDo: aBlock [
 				gcBuffer := nil]
 ]
 
-{ #category : #'private/initialization' }
+{ #category : #initialization }
 ODBObjectIndexFile >> initialize [
 
     start := self headerLength + 16.

--- a/src/OmniBase/ODBObjectManager.class.st
+++ b/src/OmniBase/ODBObjectManager.class.st
@@ -267,7 +267,6 @@ ODBObjectManager >> initContainerAt: position [
 
 { #category : #initialization }
 ODBObjectManager >> initialize [
-        "Private - Initialize receiver."
 
     containers := Array new: 32
 ]

--- a/src/OmniBase/ODBSerializer.class.st
+++ b/src/OmniBase/ODBSerializer.class.st
@@ -74,7 +74,7 @@ ODBSerializer >> cantSave: anObject [
 	anObject class name , ' can''t be stored!' odbSerialize: self
 ]
 
-{ #category : #private }
+{ #category : #initialization }
 ODBSerializer >> initialize [
 
 	externalObjects := ODBIdentityDictionary new: 127

--- a/src/OmniBase/ODBSortedDictionary.class.st
+++ b/src/OmniBase/ODBSortedDictionary.class.st
@@ -125,7 +125,7 @@ ODBSortedDictionary >> includes: aKey [
     ^(self findKey: aKey) > 0
 ]
 
-{ #category : #'private/initialization' }
+{ #category : #initialization }
 ODBSortedDictionary >> initialize [
 
     keys := Array new: 128.

--- a/src/OmniBase/ODBTransaction.class.st
+++ b/src/OmniBase/ODBTransaction.class.st
@@ -201,7 +201,7 @@ ODBTransaction >> getTransactionObject: anObject ifAbsent: aBlock [
 	^transactionObject isNil ifTrue: [aBlock value] ifFalse: [transactionObject]
 ]
 
-{ #category : #private }
+{ #category : #initialization }
 ODBTransaction >> initialize [
 	cacheMutex := Semaphore forMutualExclusion.
 	objects := ODBObjectIDDictionary new.

--- a/src/OmniBase/ODBTransactionFile.class.st
+++ b/src/OmniBase/ODBTransactionFile.class.st
@@ -47,7 +47,7 @@ OmniBase 1.0, David Gorisek (c) 1998
 '
 ]
 
-{ #category : #'private/initialization' }
+{ #category : #initialization }
 ODBTransactionFile >> initialize [
 
     locks := OrderedCollection new.

--- a/src/OmniBase/OmniBase.class.st
+++ b/src/OmniBase/OmniBase.class.st
@@ -119,7 +119,7 @@ OmniBase class >> getCurrentAndSet: anOmniBaseTransaction for: aProcess [
 	^previousTxn
 ]
 
-{ #category : #public }
+{ #category : #'class initialization' }
 OmniBase class >> initialize [
 	processToTransactionMutex isNil 
 		ifTrue: 


### PR DESCRIPTION
- categorize all #initialize method correctly
- remove useless comment   "Private - Initialize receiver."
- add a flag: to one initialize with a code smell