### PR TITLE
Fix 32: #isImmediate

### DIFF
--- a/src/OmniBase-Tests/ODBPersistentDictionaryTest.class.st
+++ b/src/OmniBase-Tests/ODBPersistentDictionaryTest.class.st
@@ -16,6 +16,15 @@ ODBPersistentDictionaryTest >> testAdd [
 ]
 
 { #category : #tests }
+ODBPersistentDictionaryTest >> testAddImmediateObject [
+	| dict |
+	[ dict := OmniBase newPersistentDictionary
+		add: (#test -> 1);
+		yourself] evaluateAndCommitIn: db newTransaction.
+	self assert: (dict at: #test) equals: 1.
+]
+
+{ #category : #tests }
 ODBPersistentDictionaryTest >> testNewPersistentDictionary [
 	| dict |
 	[ dict := OmniBase newPersistentDictionary

--- a/src/OmniBase/ODBExpiredProxyObject.class.st
+++ b/src/OmniBase/ODBExpiredProxyObject.class.st
@@ -82,14 +82,6 @@ ODBExpiredProxyObject >> isIdenticalTo: anObject [
 ]
 
 { #category : #public }
-ODBExpiredProxyObject >> isImmediate [
-	"Private - Answer whether the receiver has an immediate representation (that is it is entirely
-	encoded in an object pointer, e.g. SmallIntegers. Most objects are not immediate."
-
-	^false
-]
-
-{ #category : #public }
 ODBExpiredProxyObject >> isODBExpired [
 
 	^ true

--- a/src/OmniBase/ODBPersistentDictionary.class.st
+++ b/src/OmniBase/ODBPersistentDictionary.class.st
@@ -27,7 +27,7 @@ ODBPersistentDictionary >> add: anAssociation [
 	super add: anAssociation.
 	transaction := t.
 	transaction isNil ifTrue: [^anAssociation].
-	anAssociation value isImmediate 
+	anAssociation value isImmediateObject 
 		ifFalse: [transaction makePersistent: anAssociation value].
 	transaction markDirty: self.
 	^anAssociation
@@ -52,7 +52,7 @@ ODBPersistentDictionary >> at: key put: value [
 	transaction := oldValue.
 	transaction isNil ifTrue: [^value].
 	transaction markDirty: self.
-	(value isImmediate or: [value == key]) ifFalse: [transaction makePersistent: value].
+	(value isImmediateObject or: [value == key]) ifFalse: [transaction makePersistent: value].
 	^value
 ]
 
@@ -81,7 +81,7 @@ ODBPersistentDictionary >> odbMadePersistentIn: anOmniBaseTransaction [
 	transaction notNil 
 		ifTrue: [self error: 'Object is already persistent in another transaction'].
 	transaction := anOmniBaseTransaction.
-	self do: [:each | each isImmediate ifFalse: [transaction makePersistent: each]]
+	self do: [:each | each isImmediateObject ifFalse: [transaction makePersistent: each]]
 ]
 
 { #category : #public }

--- a/src/OmniBase/ODBReference.class.st
+++ b/src/OmniBase/ODBReference.class.st
@@ -62,14 +62,6 @@ ODBReference >> isIdenticalTo: anObject [
 	^self odbTransactionObject value == anObject
 ]
 
-{ #category : #public }
-ODBReference >> isImmediate [
-	"Private - Answer whether the receiver has an immediate representation (that is it is entirely
-	encoded in an object pointer, e.g. SmallIntegers. Most objects are not immediate."
-
-	^false
-]
-
 { #category : #hacks }
 ODBReference >> isMorph [
 	^ false

--- a/src/OmniBase/Object.extension.st
+++ b/src/OmniBase/Object.extension.st
@@ -26,11 +26,6 @@ Object >> isIdenticalTo: anObject [
 ]
 
 { #category : #'*omnibase' }
-Object >> isImmediate [
-	^false
-]
-
-{ #category : #'*omnibase' }
 Object >> isODBExpired [ 
 
 	^ false
@@ -153,7 +148,7 @@ Object >> odbGetTransaction [
 	"immediate objects can not be made persistent"
 
 	| allReferences |
-	self isImmediate ifTrue: [^nil].
+	self isImmediateObject ifTrue: [^nil].
 
 	"first check all inst vars if any references a proxy from which we could get a reference to transaction"
 	self class isBits


### PR DESCRIPTION
- #isImmediate was renamed  isImmediateObject in Pharo
- #odbGetTransaction is called only by #markDirty, which has no senders
- Any other use is *storing* in ODBPersistentDictionary, thus reading existing PersistentDictionary instances should not be impacted
- #isImmediateObject is implemented in ProtoObject, so the proxy classes do not need to re-implement
- add ODBPersistentDictionaryTest>>#testAddImmediateObject

fixes #32