### PR TITLE
Cleanup-atIfAbsentPutValue

### DIFF
--- a/src/OmniBase/ODBIdentityDictionary.class.st
+++ b/src/OmniBase/ODBIdentityDictionary.class.st
@@ -79,11 +79,6 @@ ODBIdentityDictionary >> at: anObject ifAbsentPut: aBlock [
 ]
 
 { #category : #public }
-ODBIdentityDictionary >> at: aKey ifAbsentPutValue: anObject [ 
-	^self at: aKey ifAbsent: [self at: aKey put: anObject]
-]
-
-{ #category : #public }
 ODBIdentityDictionary >> at: aKey put: anObject [ 
 	"Answer anObject. If aKey exists in the receiver,
 	replace the corresponding value with anObject, else

--- a/src/OmniBase/ODBObjectIDDictionary.class.st
+++ b/src/OmniBase/ODBObjectIDDictionary.class.st
@@ -23,11 +23,11 @@ ODBObjectIDDictionary >> at: objectID [
 ]
 
 { #category : #public }
-ODBObjectIDDictionary >> at: objectID ifAbsentPutValue: anObject [ 
+ODBObjectIDDictionary >> at: objectID ifAbsentPut: anObject [ 
 	| dict |
 	(dict := dictionaries at: objectID containerID) isNil 
 		ifTrue: [dictionaries at: objectID containerID put: (dict := ODBIdentityDictionary new)].
-	^dict at: objectID index ifAbsentPutValue: anObject
+	^dict at: objectID index ifAbsentPut: anObject
 ]
 
 { #category : #public }

--- a/src/OmniBase/ODBSerializer.class.st
+++ b/src/OmniBase/ODBSerializer.class.st
@@ -95,7 +95,7 @@ ODBSerializer >> register: anObject [
 							[self saveExternalReference: id.
 							^true]].
 			^false].
-	(id := dict at: anObject ifAbsentPutValue: counter + 1) > counter 
+	(id := dict at: anObject ifAbsentPut: counter + 1) > counter 
 		ifTrue: 
 			[counter := id.
 			anObject == mainObject 


### PR DESCRIPTION
ODBIdentityDictionary defines a very odd method not found in any other dictionary in Pharo:  #at:ifAbsentPutValue:

This is the same as at:ifAbsentPut:, but not sending #value to the block/object to be added. This allows the user to not wrap the argument in a block, which is slow as the block is created at runtime.

In Pharo this is not needed, as we have implemented #value on Object. This allows us to use the "no block" pattern with at:ifAbsentPut:

This PR 
	- changes the one sender 
	-  ODBIdentityDictionary should implement  at:ifAbsentPut: