### PR TITLE
41-Trivial-Clean-Duplicated-methods-in-the-hierarchy

### DIFF
--- a/src/OmniBase-Tests/ODBCleanCodeTest.class.st
+++ b/src/OmniBase-Tests/ODBCleanCodeTest.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #ODBCleanCodeTest,
+	#superclass : #TestCase,
+	#pools : [
+		'ODBTypeCodes'
+	],
+	#category : #'OmniBase-Tests'
+}
+
+{ #category : #tests }
+ODBCleanCodeTest >> testNoDuplicatedMethodInHierarchy [
+	"There should be no methods in the hierachy that are already in a superclass"
+	
+	| methods |
+	methods :=  OmniBase package methods reject: [:method | method isFromTrait].
+	methods := methods select: [:method |
+	method methodClass superclass
+ 		ifNotNil: [ :superclass | (superclass lookupSelector: method selector)
+ 			ifNotNil: [ :overridenMethod | method equivalentTo: overridenMethod ]
+ 			ifNil: [ false ] ]
+ 		ifNil: [ false ]].
+		self 
+		assert: methods isEmpty 
+		description: ('the following methods are already in the superclass hierarchy and can be removed: ', methods asString)
+]

--- a/src/OmniBase/ODBChange.class.st
+++ b/src/OmniBase/ODBChange.class.st
@@ -31,11 +31,6 @@ ODBChange >> commit [
 ODBChange >> committed [
 ]
 
-{ #category : #initialization }
-ODBChange >> initialize [
-	
-]
-
 { #category : #public }
 ODBChange >> loadFromStream: aStream [ 
 	"Load receiver from aStream.  Implemented by subclasses."

--- a/src/OmniBase/ODBExpiredProxyObject.class.st
+++ b/src/OmniBase/ODBExpiredProxyObject.class.st
@@ -13,16 +13,6 @@ ODBExpiredProxyObject class >> on: oid [
 ]
 
 { #category : #public }
-ODBExpiredProxyObject >> == anObject [
-	"Answer true if the receiver and the argument are the same object (have the same
-	object pointer) and false otherwise.  Do not redefine the message == in any
-	other class!  No Lookup."
-
-	<primitive: 110>
-	self primitiveFailed
-]
-
-{ #category : #public }
 ODBExpiredProxyObject >> becomeForward: otherObject [ 
 	"Primitive. All variables in the entire system that used to point
 	to the receiver now point to the argument.

--- a/src/OmniBase/ODBFile.class.st
+++ b/src/OmniBase/ODBFile.class.st
@@ -99,10 +99,6 @@ ODBFile >> headerLength [
 	^128
 ]
 
-{ #category : #initialization }
-ODBFile >> initialize [
-]
-
 { #category : #'create/open/close' }
 ODBFile >> openExclusivelyOn: aString [
 

--- a/src/OmniBase/ODBReference.class.st
+++ b/src/OmniBase/ODBReference.class.st
@@ -8,16 +8,6 @@ Class {
 	#category : #'OmniBase-Model'
 }
 
-{ #category : #'predefined intercepted messages' }
-ODBReference >> == anObject [
-	"Answer true if the receiver and the argument are the same object (have the same
-	object pointer) and false otherwise.  Do not redefine the message == in any
-	other class!  No Lookup."
-
-	<primitive: 110>
-	self primitiveFailed
-]
-
 { #category : #accessing }
 ODBReference >> demandLoader [
 
@@ -74,12 +64,6 @@ ODBReference >> isImmediate [
 ODBReference >> isMorph [
 	^ false
 
-]
-
-{ #category : #'predefined intercepted messages' }
-ODBReference >> isNil [
-
-    ^false
 ]
 
 { #category : #public }

--- a/src/OmniBase/ODBTransactionObject.class.st
+++ b/src/OmniBase/ODBTransactionObject.class.st
@@ -22,10 +22,6 @@ ODBTransactionObject >> dataBaseObject [
     ^dataBaseObject
 ]
 
-{ #category : #initialization }
-ODBTransactionObject >> initialize [
-]
-
 { #category : #'transaction processing' }
 ODBTransactionObject >> isLocked [
         "Answer <true> if the receiver is localy locked."


### PR DESCRIPTION
- remove the duplicated methods
- add #testNoDuplicatedMethodInHierarchy so we do not add more later

Fixes #41