### PR TITLE
Cleanup #new: do not send #initialize twice

### DIFF
--- a/src/OmniBase/ODBBTreeIntegerIndexDictionary.class.st
+++ b/src/OmniBase/ODBBTreeIntegerIndexDictionary.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'OmniBase-Transaction'
 }
 
-{ #category : #public }
+{ #category : #'instance creation' }
 ODBBTreeIntegerIndexDictionary class >> new [
 	^super new keySize: 4
 ]

--- a/src/OmniBase/ODBChange.class.st
+++ b/src/OmniBase/ODBChange.class.st
@@ -17,11 +17,6 @@ ODBChange class >> changeClassID [
 	^nil
 ]
 
-{ #category : #public }
-ODBChange class >> new [
-	^super new initialize
-]
-
 { #category : #'transaction processing' }
 ODBChange >> commit [
         "Commit changes."

--- a/src/OmniBase/ODBChangesPackage.class.st
+++ b/src/OmniBase/ODBChangesPackage.class.st
@@ -7,12 +7,6 @@ Class {
 	#category : #'OmniBase-Events'
 }
 
-{ #category : #'as yet unclassified' }
-ODBChangesPackage class >> new [
-
-    ^super new initialize
-]
-
 { #category : #public }
 ODBChangesPackage >> add: aChange [ 
 	changes add: aChange

--- a/src/OmniBase/ODBClassManager.class.st
+++ b/src/OmniBase/ODBClassManager.class.st
@@ -11,12 +11,6 @@ Class {
 	#category : #'OmniBase-Base'
 }
 
-{ #category : #'as yet unclassified' }
-ODBClassManager class >> new [
-
-    ^super new initialize
-]
-
 { #category : #private }
 ODBClassManager >> addClassDescription: aClassDescription withId: classId [ 
 	"Private - Add aClassDescription under a given ID."

--- a/src/OmniBase/ODBClient.class.st
+++ b/src/OmniBase/ODBClient.class.st
@@ -11,12 +11,6 @@ Class {
 	#category : #'OmniBase-Base'
 }
 
-{ #category : #'instance creation' }
-ODBClient class >> new [
-
-    ^super new initialize
-]
-
 { #category : #'public/accessing' }
 ODBClient >> clientID [
         "Answer client ID."

--- a/src/OmniBase/ODBContainer.class.st
+++ b/src/OmniBase/ODBContainer.class.st
@@ -18,12 +18,6 @@ Class {
 	#category : #'OmniBase-Storage'
 }
 
-{ #category : #'instance creation' }
-ODBContainer class >> new [
-
-    ^super new initialize
-]
-
 { #category : #public }
 ODBContainer >> addByteStorageRequest: anODBByteStorageRequest [ 
 	byteStorageQueue add: anODBByteStorageRequest.

--- a/src/OmniBase/ODBMemoryWriteStream.class.st
+++ b/src/OmniBase/ODBMemoryWriteStream.class.st
@@ -10,12 +10,6 @@ Class {
 	#category : #'OmniBase-Streams'
 }
 
-{ #category : #'instance creation' }
-ODBMemoryWriteStream class >> new [
-
-    ^super new initialize
-]
-
 { #category : #public }
 ODBMemoryWriteStream >> asByteArray [
 	"Answer receiver as byte array."

--- a/src/OmniBase/ODBObjectHolder.class.st
+++ b/src/OmniBase/ODBObjectHolder.class.st
@@ -15,7 +15,7 @@ ODBObjectHolder class >> createOn: aByteArray [
     ^self basicNew createOn: aByteArray
 ]
 
-{ #category : #private }
+{ #category : #'instance creation' }
 ODBObjectHolder class >> new [
 
     ^super new initialize

--- a/src/OmniBase/ODBObjectID.class.st
+++ b/src/OmniBase/ODBObjectID.class.st
@@ -14,7 +14,7 @@ ODBObjectID class >> containerID: containerID index: index [
     ^super new containerID: containerID index: index
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 ODBObjectID class >> new [
 
     ^super new containerID: 0 index: 0

--- a/src/OmniBase/ODBObjectIDDictionary.class.st
+++ b/src/OmniBase/ODBObjectIDDictionary.class.st
@@ -7,12 +7,6 @@ Class {
 	#category : #'OmniBase-Model'
 }
 
-{ #category : #'as yet unclassified' }
-ODBObjectIDDictionary class >> new [
-
-    ^super new initialize
-]
-
 { #category : #public }
 ODBObjectIDDictionary >> at: objectID [ 
 	"Answer transaction object at objectID or <nil> if absent."

--- a/src/OmniBase/ODBObjectManager.class.st
+++ b/src/OmniBase/ODBObjectManager.class.st
@@ -10,12 +10,6 @@ Class {
 	#category : #'OmniBase-Base'
 }
 
-{ #category : #private }
-ODBObjectManager class >> new [
-
-    ^super new initialize
-]
-
 { #category : #'create/open/close' }
 ODBObjectManager >> close [
         "Close object manager and all opened containers."

--- a/src/OmniBase/ODBSerializer.class.st
+++ b/src/OmniBase/ODBSerializer.class.st
@@ -17,12 +17,6 @@ Class {
 }
 
 { #category : #public }
-ODBSerializer class >> new [
-
-	^ super new 
-]
-
-{ #category : #public }
 ODBSerializer class >> serialize: anObject on: aWriteStream [ 
 	| classManager byteStream byteStream2 |
 	classManager := ODBClassManagerForSerialization new initializeForSerialization.

--- a/src/OmniBase/ODBSortedDictionary.class.st
+++ b/src/OmniBase/ODBSortedDictionary.class.st
@@ -10,12 +10,6 @@ Class {
 	#category : #'OmniBase-Model'
 }
 
-{ #category : #'as yet unclassified' }
-ODBSortedDictionary class >> new [
-
-    ^super new initialize
-]
-
 { #category : #public }
 ODBSortedDictionary >> at: aKey [ 
 	| index |

--- a/src/OmniBase/ODBTransaction.class.st
+++ b/src/OmniBase/ODBTransaction.class.st
@@ -16,12 +16,6 @@ Class {
 }
 
 { #category : #private }
-ODBTransaction class >> new [
-
-	^super new initialize
-]
-
-{ #category : #private }
 ODBTransaction class >> odbDeserialize: deserializer [
 
 	^deserializer transaction

--- a/src/OmniBase/ODBTransactionObject.class.st
+++ b/src/OmniBase/ODBTransactionObject.class.st
@@ -10,12 +10,6 @@ Class {
 	#category : #'OmniBase-Transaction'
 }
 
-{ #category : #'instance creation' }
-ODBTransactionObject class >> new [
-
-    ^super new initialize
-]
-
 { #category : #accessing }
 ODBTransactionObject >> dataBaseObject [
 

--- a/src/OmniBase/OmniBase.class.st
+++ b/src/OmniBase/OmniBase.class.st
@@ -127,10 +127,10 @@ OmniBase class >> initialize [
 			processToTransactionMutex := Semaphore forMutualExclusion]
 ]
 
-{ #category : #private }
+{ #category : #'instance creation' }
 OmniBase class >> new [
 	self initialize.
-	^super new initialize
+	^super new
 ]
 
 { #category : #public }


### PR DESCRIPTION
- remove all non-needed #new implementations
- categorize the remaining method correctly

ODBObjectHolder class>>#new is a bit odd,  but as the superclass overrides new to *not* do #iniialize,  it is correct

This PR removes thus all the cases where we were sending #initialize twice.