### PR TITLE
Introduce image wide lock registry

### DIFF
--- a/src/OmniBase-Tests/ODBConcurrentTest.class.st
+++ b/src/OmniBase-Tests/ODBConcurrentTest.class.st
@@ -34,6 +34,7 @@ ODBConcurrentTest >> testBTreeKeyLocking [
 
 	t1 commit.
 	t2 commit.
+
 	t1 := db newTransaction.
 	t2 := db2 newTransaction.
 	dict := t1 root at: 'concurrent-btree'.

--- a/src/OmniBase-Tests/ODBConcurrentTest.class.st
+++ b/src/OmniBase-Tests/ODBConcurrentTest.class.st
@@ -69,7 +69,7 @@ ODBConcurrentTest >> testBTreeKeyLocking [
 ]
 
 { #category : #tests }
-ODBConcurrentTest >> testObjectLocking2 [
+ODBConcurrentTest >> testObjectLockingDifferentDatabases [
 
 	"Test if object locking works with transactions running in two database connections."
 
@@ -114,4 +114,50 @@ ODBConcurrentTest >> testObjectLocking2 [
 	coll := t2 root at: 'lockTest'.
 	self assert: coll first equals: 'Changed collection' ] ensure: [ 
 		db2 close ]
+]
+
+{ #category : #tests }
+ODBConcurrentTest >> testObjectLockingSameDatabase [
+
+	"Test if object locking works with transactions running in two database connections."
+
+	"This test fails on unix based systems as locking does not rely solely on file locking but
+	on the database connection. If there are two connections it does not work"
+
+	| t1 t2 coll collCopy |
+	[ 
+	[ 
+	coll := OrderedCollection with: 'This collection will be locked'.
+	OmniBase root at: 'lockTest' put: coll ] evaluateAndCommitIn:
+		db newTransaction.
+	"test"
+	t1 := db newTransaction.
+	t2 := db newTransaction.
+	coll := t1 root at: 'lockTest'.
+	self halt.
+	self assert: (t1 lock: coll).
+	collCopy := t2 root at: 'lockTest'.
+	self deny: (t2 lock: collCopy).
+	t1 abort.
+	self assert: (t2 lock: collCopy).
+	t1 := db newTransaction.
+	coll := t1 root at: 'lockTest'.
+	coll first.
+	self deny: (t1 lock: coll).
+	t2 unlock: collCopy.
+	t2 := db newTransaction.
+	self assert: (t1 lock: coll).
+	coll at: 1 put: 'Changed collection'.
+	t1
+		markDirty: coll;
+		commit.
+	collCopy := t2 root at: 'lockTest'.
+	self assert: collCopy first equals: 'This collection will be locked'.
+	self deny: (t2 lock: collCopy).
+	"wait here a little since changes are updated every half a second (500 ms)"
+	(Delay forMilliseconds: 501) wait.
+	t2 := db newTransaction.
+	coll := t2 root at: 'lockTest'.
+	self assert: coll first equals: 'Changed collection' ] ensure: [ 
+		db close ]
 ]

--- a/src/OmniBase-Tests/ODBConcurrentTest.class.st
+++ b/src/OmniBase-Tests/ODBConcurrentTest.class.st
@@ -4,11 +4,6 @@ Class {
 	#category : #'OmniBase-Tests'
 }
 
-{ #category : #testing }
-ODBConcurrentTest >> expectedFailures [ 
-	^ #( testObjectLocking2 )
-]
-
 { #category : #tests }
 ODBConcurrentTest >> testBTreeKeyLocking [
 
@@ -134,7 +129,6 @@ ODBConcurrentTest >> testObjectLockingSameDatabase [
 	t1 := db newTransaction.
 	t2 := db newTransaction.
 	coll := t1 root at: 'lockTest'.
-	self halt.
 	self assert: (t1 lock: coll).
 	collCopy := t2 root at: 'lockTest'.
 	self deny: (t2 lock: collCopy).

--- a/src/OmniBase-Tests/ODBDatabaseTest.class.st
+++ b/src/OmniBase-Tests/ODBDatabaseTest.class.st
@@ -51,7 +51,7 @@ ODBDatabaseTest >> benchmarkCommitNewObjects [
 
 { #category : #testing }
 ODBDatabaseTest >> expectedFailures [ 
-	^ #( testBackup testObjectLocking )
+	^ #( testBackup )
 ]
 
 { #category : #tests }

--- a/src/OmniBase-Tests/ODBDiskBasedTest.class.st
+++ b/src/OmniBase-Tests/ODBDiskBasedTest.class.st
@@ -41,5 +41,6 @@ ODBDiskBasedTest >> setUp [
 { #category : #running }
 ODBDiskBasedTest >> tearDown [
 	db ifNotNil: [ db close ].
+	ODBLockRegistry reset.
 	self deleteDatabaseOnFileSystem 
 ]

--- a/src/OmniBase-Tests/ODBDiskBasedTest.class.st
+++ b/src/OmniBase-Tests/ODBDiskBasedTest.class.st
@@ -40,6 +40,6 @@ ODBDiskBasedTest >> setUp [
 
 { #category : #running }
 ODBDiskBasedTest >> tearDown [
-	db close.
+	db ifNotNil: [ db close ].
 	self deleteDatabaseOnFileSystem 
 ]

--- a/src/OmniBase-Tests/ODBLockRegistryTest.class.st
+++ b/src/OmniBase-Tests/ODBLockRegistryTest.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #ODBLockRegistryTest,
+	#superclass : #ODBDiskBasedTest,
+	#category : #'OmniBase-Tests'
+}
+
+{ #category : #tests }
+ODBLockRegistryTest >> testRegisterByOpeningDatabase [ 
+	self assert: ODBLockRegistry registeredPaths size equals: 1
+]

--- a/src/OmniBase-Tests/ODBLockRegistryTest.class.st
+++ b/src/OmniBase-Tests/ODBLockRegistryTest.class.st
@@ -5,6 +5,24 @@ Class {
 }
 
 { #category : #tests }
+ODBLockRegistryTest >> testAddLock [ 
+	| tx col |
+	tx := db newTransaction.
+	col := OrderedCollection with: #foo.
+	[tx makePersistent: col.
+	tx checkpoint.
+	tx lock: col.
+	self assert: db lockRegistry size equals: 1]
+		ensure: [ tx abort ]
+]
+
+{ #category : #tests }
 ODBLockRegistryTest >> testRegisterByOpeningDatabase [ 
-	self assert: ODBLockRegistry registeredPaths size equals: 1
+	self assert: ODBLockRegistry registeredPaths size equals: 1.
+	db close.
+	db := nil.
+	Smalltalk garbageCollect .
+	Smalltalk garbageCollect .
+	Smalltalk garbageCollect .
+	self assert: ODBLockRegistry registeredPaths size equals: 0 
 ]

--- a/src/OmniBase-Tests/ODBObjectManagerTest.class.st
+++ b/src/OmniBase-Tests/ODBObjectManagerTest.class.st
@@ -21,7 +21,7 @@ ODBObjectManagerTest >> tearDown [
 
 { #category : #tests }
 ODBObjectManagerTest >> testClassVersionReshapes [
-	| tmpClass obj1 obj2 transaction2 transaction info1 info2 |
+	| tmpClass obj1 obj2 transaction info1 info2 |
 	tmpClass := ODBTestClass1 copy.
 	self assertCollection: tmpClass instVarNames hasSameElements: #( one two three).
 	obj1 := tmpClass new 
@@ -48,12 +48,7 @@ ODBObjectManagerTest >> testClassVersionReshapes [
 
 	self assert: obj2 one equals: 'one2'.
 	self assert: obj2 two equals: 'two2'.
-	self assert: obj2 three equals: 'three2'.
-
-	transaction2 := db newTransaction.
-	transaction2 root at: 'test2' put: obj2.
-	transaction2 commit.
-		
+	self assert: obj2 three equals: 'three2'
 ]
 
 { #category : #tests }

--- a/src/OmniBase/ODBBTreeDictionary.class.st
+++ b/src/OmniBase/ODBBTreeDictionary.class.st
@@ -69,7 +69,8 @@ ODBBTreeDictionary >> basicLockKey: key [
 				key: key.
 	value := self valueAt: key.
 	dataBaseObject iterator critical: 
-			[transaction addLoggedLock: lock.
+			[
+			(transaction addLoggedLock: lock) ifFalse: [ ^ false ].
 			((dataBaseObject iterator)
 				goTo: key;
 				lockCurrentValue: value contents with: lockID) 

--- a/src/OmniBase/ODBBTreeDictionary.class.st
+++ b/src/OmniBase/ODBBTreeDictionary.class.st
@@ -2,7 +2,6 @@ Class {
 	#name : #ODBBTreeDictionary,
 	#superclass : #ODBBTreeIndexDictionary,
 	#instVars : [
-		'locks',
 		'initialSize',
 		'deltaSize'
 	],
@@ -60,9 +59,16 @@ ODBBTreeDictionary >> basicLockKey: key [
 	dataBaseObject isNil ifTrue: [^true].
 	(lockID := transaction lockID) isNil ifTrue: [^false].
 	transaction isGlobalLocked ifTrue: [^true].
-	locks isNil 
-		ifTrue: [locks := Dictionary new]
-		ifFalse: [(locks includesKey: key) ifTrue: [^true]].
+	"Does the registry contain a lock for this dictionary and key?"
+	lock := transaction 
+		keyLockOn: self
+		key: key 
+		ifAbsent: [ nil ]. 
+	"A present lock is either inside the current transaction which makes
+	it succeed or it is part of another transaction which indicates a
+	locking conflict"
+	lock ifNotNil: [  
+		^ lock isSameTransaction: transaction ].
 	lock := (ODBKeyLock new)
 				objectID: holder objectID;
 				lockID: lockID;
@@ -77,7 +83,6 @@ ODBBTreeDictionary >> basicLockKey: key [
 					ifFalse: 
 						[transaction removeLoggedLock: lock.
 						^false]].
-	locks at: key put: lock.
 	^true
 ]
 
@@ -166,7 +171,7 @@ ODBBTreeDictionary >> isKeyLocked: aKey [
 	transaction isGlobalLocked ifTrue: [^false].
 	key := self bytesFromKey: aKey.
 	dataBaseObject iterator critical: 
-			[result := (locks notNil and: [locks includesKey: key]) or: 
+			[result := (self hasLockAt: aKey ) or: 
 							[(dataBaseObject iterator)
 								goTo: key;
 								isLocked]].
@@ -247,10 +252,9 @@ ODBBTreeDictionary >> unlockKey: aKey [
 	dataBaseObject isNil ifTrue: [^true].
 	key := self bytesFromKey: aKey.
 	changed isNil ifFalse: [(changed includes: key) ifTrue: [^false]].
-	locks isNil ifTrue: [^transaction isGlobalLocked].
-	lock := locks at: key ifAbsent: [^false].
+	transaction locks ifEmpty: [ ^ transaction isGlobalLocked ].
+	lock := transaction keyLockOn: self key: key ifAbsent: [ ^ false ]. 
 	(dataBaseObject unlockKey: key with: lock lockID) ifFalse: [^false].
 	transaction removeLoggedLock: lock.
-	locks removeKey: key.
 	^true
 ]

--- a/src/OmniBase/ODBBTreeDictionary.class.st
+++ b/src/OmniBase/ODBBTreeDictionary.class.st
@@ -252,7 +252,7 @@ ODBBTreeDictionary >> unlockKey: aKey [
 	dataBaseObject isNil ifTrue: [^true].
 	key := self bytesFromKey: aKey.
 	changed isNil ifFalse: [(changed includes: key) ifTrue: [^false]].
-	transaction locks ifEmpty: [ ^ transaction isGlobalLocked ].
+	transaction hasLocks ifFalse: [ ^ transaction isGlobalLocked ].
 	lock := transaction keyLockOn: self key: key ifAbsent: [ ^ false ]. 
 	(dataBaseObject unlockKey: key with: lock lockID) ifFalse: [^false].
 	transaction removeLoggedLock: lock.

--- a/src/OmniBase/ODBBTreeIndexDictionary.class.st
+++ b/src/OmniBase/ODBBTreeIndexDictionary.class.st
@@ -344,6 +344,13 @@ ODBBTreeIndexDictionary >> goTo: aKey [
 	self basicGoTo: (self bytesFromKey: aKey)
 ]
 
+{ #category : #testing }
+ODBBTreeIndexDictionary >> hasLockAt: key [ 
+	^ transaction 
+		hasKeyLockOn: self
+		key: key
+]
+
 { #category : #public }
 ODBBTreeIndexDictionary >> includesKey: aKey [ 
 	| value |
@@ -430,6 +437,11 @@ ODBBTreeIndexDictionary >> last: anInteger [
 		result add: current value].
 	
 	^ result
+]
+
+{ #category : #accessing }
+ODBBTreeIndexDictionary >> lockRegistryKeyAt: aKey [
+	^ self objectID lockRegistryKeyAt: aKey
 ]
 
 { #category : #initialization }

--- a/src/OmniBase/ODBKeyLock.class.st
+++ b/src/OmniBase/ODBKeyLock.class.st
@@ -36,13 +36,8 @@ ODBKeyLock >> loadFromStream: aStream [
 ]
 
 { #category : #'as yet unclassified' }
-ODBKeyLock >> registryKeyOn: aStream [ 
-	aStream 
-		<< objectID containerID asString 
-		<< ':' 
-		<< objectID index asString
-		<< ':'
-		<< key asInteger asString
+ODBKeyLock >> lockRegistryKey [ 
+	^ objectID lockRegistryKeyAt: key
 ]
 
 { #category : #'public/load/store' }

--- a/src/OmniBase/ODBKeyLock.class.st
+++ b/src/OmniBase/ODBKeyLock.class.st
@@ -35,6 +35,16 @@ ODBKeyLock >> loadFromStream: aStream [
     key := aStream getString asByteArray
 ]
 
+{ #category : #'as yet unclassified' }
+ODBKeyLock >> registryKeyOn: aStream [ 
+	aStream 
+		<< objectID containerID asString 
+		<< ':' 
+		<< objectID index asString
+		<< ':'
+		<< key asInteger asString
+]
+
 { #category : #'public/load/store' }
 ODBKeyLock >> storeOnStream: aStream [
 

--- a/src/OmniBase/ODBLocalTransaction.class.st
+++ b/src/OmniBase/ODBLocalTransaction.class.st
@@ -99,8 +99,13 @@ ODBLocalTransaction >> committed [
 ]
 
 { #category : #testing }
+ODBLocalTransaction >> hasForeignLockFor: anODBObjectID [ 
+	^ lockRegistry hasForeignLockFor: anODBObjectID transaction: self
+]
+
+{ #category : #testing }
 ODBLocalTransaction >> hasLockFor: anODBObjectID [ 
-	^ lockRegistry hasLockFor: anODBObjectID 
+	^ lockRegistry hasForeignLockFor: anODBObjectID transaction: self
 ]
 
 { #category : #initialization }

--- a/src/OmniBase/ODBLocalTransaction.class.st
+++ b/src/OmniBase/ODBLocalTransaction.class.st
@@ -151,7 +151,7 @@ ODBLocalTransaction >> lockID [
 	if database is globally locked by another user and no 
 	locks can currently be set."
 
-	lockRegistry isEmpty 
+	(lockRegistry locksWithTransaction: self) isEmpty 
 		ifTrue: 
 			[(transactionFile := client newTransactionFileFor: self) isNil ifTrue: [^nil] ].
 	^transactionFile transactionID

--- a/src/OmniBase/ODBLocalTransaction.class.st
+++ b/src/OmniBase/ODBLocalTransaction.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #private }
 ODBLocalTransaction >> addLock: anObjectLock [
-        "Private - Add aLock to receiver."
+   "Private - Add aLock to receiver."
 	anObjectLock transaction: self.
 	locks add: anObjectLock.
    ^ lockRegistry addLock: anObjectLock
@@ -116,7 +116,8 @@ ODBLocalTransaction >> hasKeyLockOn: aBtreeDictionary key: aCollection [
 ]
 
 { #category : #testing }
-ODBLocalTransaction >> hasLocks [ 	
+ODBLocalTransaction >> hasLocks [
+ 	
 	^ locks notEmpty
 ]
 

--- a/src/OmniBase/ODBLocalTransaction.class.st
+++ b/src/OmniBase/ODBLocalTransaction.class.st
@@ -11,19 +11,19 @@ Class {
 }
 
 { #category : #private }
-ODBLocalTransaction >> addLock: aLock [
+ODBLocalTransaction >> addLock: anObjectLock [
         "Private - Add aLock to receiver."
-	aLock transaction: self.
-   ^ lockRegistry addLock: aLock
+	anObjectLock transaction: self.
+   ^ lockRegistry addLock: anObjectLock
 ]
 
 { #category : #private }
-ODBLocalTransaction >> addLoggedLock: aLock [ 
+ODBLocalTransaction >> addLoggedLock: aKeyLock [ 
 	"Private - Add aLock to receiver and store it to transaction file."
 
-	aLock transaction: self.
-	(lockRegistry addLock: aLock) ifFalse: [ ^ false ]. 
-	transactionFile lockAdd: aLock.
+	aKeyLock transaction: self.
+	(lockRegistry addLock: aKeyLock) ifFalse: [ ^ false ]. 
+	transactionFile lockAdd: aKeyLock.
 	^ true
 	
 ]
@@ -101,8 +101,16 @@ ODBLocalTransaction >> committed [
 ]
 
 { #category : #testing }
-ODBLocalTransaction >> hasForeignLockFor: anODBObjectID [ 
-	^ lockRegistry hasForeignLockFor: anODBObjectID transaction: self
+ODBLocalTransaction >> hasForeignLockFor: aTransactionObject [
+	^ lockRegistry hasForeignLockFor: aTransactionObject transaction: self
+]
+
+{ #category : #testing }
+ODBLocalTransaction >> hasKeyLockOn: aBtreeDictionary key: aCollection [ 
+	^ lockRegistry 
+		hasKeyLockOn: aBtreeDictionary 
+		key: aCollection 
+
 ]
 
 { #category : #initialization }
@@ -134,6 +142,14 @@ ODBLocalTransaction >> isPersistent: anObject [
 	
 	^ (self getTransactionObject: anObject ifAbsent:[nil]) notNil
 	
+]
+
+{ #category : #testing }
+ODBLocalTransaction >> keyLockOn: aBtreeDictionary key: key ifAbsent: aBlock [
+	^ lockRegistry 
+		keyLockOn: aBtreeDictionary 
+		key: key 
+		ifAbsent: aBlock
 ]
 
 { #category : #public }

--- a/src/OmniBase/ODBLocalTransaction.class.st
+++ b/src/OmniBase/ODBLocalTransaction.class.st
@@ -14,7 +14,7 @@ Class {
 ODBLocalTransaction >> addLock: aLock [
         "Private - Add aLock to receiver."
 	aLock transaction: self.
-   lockRegistry addLock: aLock
+   ^ lockRegistry addLock: aLock
 ]
 
 { #category : #private }
@@ -22,8 +22,10 @@ ODBLocalTransaction >> addLoggedLock: aLock [
 	"Private - Add aLock to receiver and store it to transaction file."
 
 	aLock transaction: self.
-	lockRegistry addLock: aLock.
-	transactionFile lockAdd: aLock
+	(lockRegistry addLock: aLock) ifFalse: [ ^ false ]. 
+	transactionFile lockAdd: aLock.
+	^ true
+	
 ]
 
 { #category : #public }
@@ -100,11 +102,6 @@ ODBLocalTransaction >> committed [
 
 { #category : #testing }
 ODBLocalTransaction >> hasForeignLockFor: anODBObjectID [ 
-	^ lockRegistry hasForeignLockFor: anODBObjectID transaction: self
-]
-
-{ #category : #testing }
-ODBLocalTransaction >> hasLockFor: anODBObjectID [ 
 	^ lockRegistry hasForeignLockFor: anODBObjectID transaction: self
 ]
 

--- a/src/OmniBase/ODBLocalTransaction.class.st
+++ b/src/OmniBase/ODBLocalTransaction.class.st
@@ -113,6 +113,11 @@ ODBLocalTransaction >> hasKeyLockOn: aBtreeDictionary key: aCollection [
 
 ]
 
+{ #category : #testing }
+ODBLocalTransaction >> hasLocks [ 	
+	^ self locks notEmpty
+]
+
 { #category : #initialization }
 ODBLocalTransaction >> initialize [
 
@@ -169,8 +174,8 @@ ODBLocalTransaction >> lockID [
 	if database is globally locked by another user and no 
 	locks can currently be set."
 
-	(lockRegistry locksWithTransaction: self) isEmpty 
-		ifTrue: 
+	self hasLocks 
+		ifFalse: 
 			[(transactionFile := client newTransactionFileFor: self) isNil ifTrue: [^nil] ].
 	^transactionFile transactionID
 ]

--- a/src/OmniBase/ODBLocalTransaction.class.st
+++ b/src/OmniBase/ODBLocalTransaction.class.st
@@ -14,6 +14,7 @@ Class {
 ODBLocalTransaction >> addLock: anObjectLock [
         "Private - Add aLock to receiver."
 	anObjectLock transaction: self.
+	locks add: anObjectLock.
    ^ lockRegistry addLock: anObjectLock
 ]
 
@@ -23,6 +24,7 @@ ODBLocalTransaction >> addLoggedLock: aKeyLock [
 
 	aKeyLock transaction: self.
 	(lockRegistry addLock: aKeyLock) ifFalse: [ ^ false ]. 
+	locks add: aKeyLock.
 	transactionFile lockAdd: aKeyLock.
 	^ true
 	
@@ -115,14 +117,15 @@ ODBLocalTransaction >> hasKeyLockOn: aBtreeDictionary key: aCollection [
 
 { #category : #testing }
 ODBLocalTransaction >> hasLocks [ 	
-	^ self locks notEmpty
+	^ locks notEmpty
 ]
 
 { #category : #initialization }
 ODBLocalTransaction >> initialize [
 
-    super initialize.
-    newObjects := Array new: 16
+	super initialize.
+	locks := OrderedCollection new.
+	newObjects := Array new: 16
 ]
 
 { #category : #public }
@@ -317,7 +320,8 @@ ODBLocalTransaction >> removeCachedObjectID: objectID [
 ODBLocalTransaction >> removeLock: aLock [ 
 	"Private - Remove aLock from collection of set locks."
 
-	lockRegistry removeLock: aLock 
+	lockRegistry removeLock: aLock.
+	locks remove: aLock ifAbsent: [  ]
 ]
 
 { #category : #private }
@@ -325,7 +329,8 @@ ODBLocalTransaction >> removeLoggedLock: aODBLock [
 	"Private - Remove anODBLock from receiver and remove it from transaction file."
 
 	lockRegistry removeLock: aODBLock.
-	transactionFile lockRemove: aODBLock
+	transactionFile lockRemove: aODBLock.
+	locks remove: aODBLock ifAbsent: [  ]
 ]
 
 { #category : #public }

--- a/src/OmniBase/ODBLocalTransaction.class.st
+++ b/src/OmniBase/ODBLocalTransaction.class.st
@@ -14,14 +14,14 @@ Class {
 ODBLocalTransaction >> addLock: aLock [
         "Private - Add aLock to receiver."
 
-    locks add: aLock
+    lockRegistry addLock: aLock
 ]
 
 { #category : #private }
 ODBLocalTransaction >> addLoggedLock: aLock [ 
 	"Private - Add aLock to receiver and store it to transaction file."
 
-	locks add: aLock.
+	lockRegistry addLock: aLock.
 	transactionFile lockAdd: aLock
 ]
 
@@ -97,6 +97,11 @@ ODBLocalTransaction >> committed [
     changesPackage := nil.
 ]
 
+{ #category : #testing }
+ODBLocalTransaction >> hasLockFor: anODBObjectID [ 
+	^ lockRegistry hasLockFor: anODBObjectID 
+]
+
 { #category : #initialization }
 ODBLocalTransaction >> initialize [
 
@@ -145,16 +150,10 @@ ODBLocalTransaction >> lockID [
 	if database is globally locked by another user and no 
 	locks can currently be set."
 
-	locks isNil 
+	lockRegistry isEmpty 
 		ifTrue: 
-			[(transactionFile := client newTransactionFileFor: self) isNil ifTrue: [^nil].
-			locks := OrderedCollection new].
+			[(transactionFile := client newTransactionFileFor: self) isNil ifTrue: [^nil] ].
 	^transactionFile transactionID
-]
-
-{ #category : #public }
-ODBLocalTransaction >> locks [
-	^ locks 
 ]
 
 { #category : #public }
@@ -294,14 +293,14 @@ ODBLocalTransaction >> removeCachedObjectID: objectID [
 ODBLocalTransaction >> removeLock: aLock [ 
 	"Private - Remove aLock from collection of set locks."
 
-	locks remove: aLock ifAbsent: []
+	lockRegistry removeLock: aLock 
 ]
 
 { #category : #private }
 ODBLocalTransaction >> removeLoggedLock: aODBLock [ 
 	"Private - Remove anODBLock from receiver and remove it from transaction file."
 
-	locks remove: aODBLock ifAbsent: [].
+	lockRegistry removeLock: aODBLock.
 	transactionFile lockRemove: aODBLock
 ]
 

--- a/src/OmniBase/ODBLock.class.st
+++ b/src/OmniBase/ODBLock.class.st
@@ -18,6 +18,11 @@ ODBLock class >> lockClassID [
 	self subclassResponsibility
 ]
 
+{ #category : #testing }
+ODBLock >> isSameTransaction: anODBLocalTransaction [ 
+	^ transaction = anODBLocalTransaction 
+]
+
 { #category : #'public/accessing' }
 ODBLock >> lockID [
 
@@ -42,6 +47,11 @@ ODBLock >> lockIndex: anInteger [
     lockIndex := anInteger.
 ]
 
+{ #category : #'as yet unclassified' }
+ODBLock >> lockRegistryKey [ 
+	^ objectID lockRegistryKey 
+]
+
 { #category : #'public/accessing' }
 ODBLock >> objectID [
 
@@ -52,12 +62,6 @@ ODBLock >> objectID [
 ODBLock >> objectID: anObjectID [
 
     objectID := anObjectID
-]
-
-{ #category : #'as yet unclassified' }
-ODBLock >> registryKey [ 
-	^ String streamContents: [ :stream |
-		self registryKeyOn: stream ]
 ]
 
 { #category : #accessing }

--- a/src/OmniBase/ODBLock.class.st
+++ b/src/OmniBase/ODBLock.class.st
@@ -54,6 +54,11 @@ ODBLock >> objectID: anObjectID [
     objectID := anObjectID
 ]
 
+{ #category : #accessing }
+ODBLock >> transaction [
+	^ transaction
+]
+
 { #category : #'public/accessing' }
 ODBLock >> transaction: aTransaction [
 

--- a/src/OmniBase/ODBLock.class.st
+++ b/src/OmniBase/ODBLock.class.st
@@ -54,6 +54,12 @@ ODBLock >> objectID: anObjectID [
     objectID := anObjectID
 ]
 
+{ #category : #'as yet unclassified' }
+ODBLock >> registryKey [ 
+	^ String streamContents: [ :stream |
+		self registryKeyOn: stream ]
+]
+
 { #category : #accessing }
 ODBLock >> transaction [
 	^ transaction

--- a/src/OmniBase/ODBLockRegistry.class.st
+++ b/src/OmniBase/ODBLockRegistry.class.st
@@ -24,7 +24,7 @@ ODBLockRegistry class >> forPath: aString [
 
 { #category : #initialization }
 ODBLockRegistry class >> initialize [ 
-	registries := WeakValueDictionary new
+	self reset
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/OmniBase/ODBLockRegistry.class.st
+++ b/src/OmniBase/ODBLockRegistry.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'path',
-		'locks'
+		'locks',
+		'mutex'
 	],
 	#classInstVars : [
 		'registries'
@@ -70,20 +71,23 @@ ODBLockRegistry >> checkRemoval [
 { #category : #testing }
 ODBLockRegistry >> hasForeignLockFor: aTransactionObject transaction: aTransaction [
 	"test if there is a lock that is present and that belongs to aTransaction"
-	^ locks 
-		at: aTransactionObject lockRegistryKey 
-		ifPresent: [ :lock | (lock transaction = aTransaction) not  ]
-		ifAbsent: [ false ]
+	^ mutex critical: [
+		locks 
+			at: aTransactionObject lockRegistryKey 
+			ifPresent: [ :lock | (lock transaction = aTransaction) not  ]
+			ifAbsent: [ false ] ]
 ]
 
 { #category : #testing }
 ODBLockRegistry >> hasKeyLockOn: aBtreeDictionary key: key [ 
-	^ locks includesKey: (aBtreeDictionary lockRegistryKeyAt: key)
+	^ mutex critical: [
+		locks includesKey: (aBtreeDictionary lockRegistryKeyAt: key) ]
 ]
 
 { #category : #initialization }
 ODBLockRegistry >> initialize [ 
 	super initialize.
+	mutex := Semaphore forMutualExclusion.
 	locks := Dictionary new
 ]
 
@@ -94,27 +98,30 @@ ODBLockRegistry >> isEmpty [
 
 { #category : #testing }
 ODBLockRegistry >> keyLockOn: aBtreeDictionary key: key ifAbsent: aBlock [
-	^ locks 
-		at: (aBtreeDictionary lockRegistryKeyAt: key) 
-		ifAbsent: aBlock
+	^ mutex critical: [
+		locks 
+			at: (aBtreeDictionary lockRegistryKeyAt: key) 
+			ifAbsent: aBlock ]
 ]
 
 { #category : #adding }
 ODBLockRegistry >> lockAt: key put: aLock [ 
-	locks 
-		at: key
-		ifPresent: [ :lock |
-			^ lock isSameTransaction: aLock transaction ].
-	locks 
-		at: key 
-		put: aLock.
+	mutex critical: [  
+		locks 
+			at: key
+			ifPresent: [ :lock |
+				^ lock isSameTransaction: aLock transaction ].
+		locks 
+			at: key 
+			put: aLock ].
 	^ true
 ]
 
 { #category : #'as yet unclassified' }
 ODBLockRegistry >> locksWithTransaction: aTransaction [ 
-	^ locks values 
-		select: [ :lock | lock transaction = aTransaction ]
+	^ mutex critical: [
+		locks values 
+			select: [ :lock | lock transaction = aTransaction ] ]
 ]
 
 { #category : #accessing }
@@ -135,15 +142,16 @@ ODBLockRegistry >> remove [
 
 { #category : #removing }
 ODBLockRegistry >> removeLock: anODBObjectLock [ 
-	locks 
-		removeKey: anODBObjectLock lockRegistryKey 
-		ifAbsent: [  ].
+	mutex critical: [
+		locks 
+			removeKey: anODBObjectLock lockRegistryKey 
+			ifAbsent: [  ] ].
 	self checkRemoval 
 ]
 
 { #category : #initialization }
 ODBLockRegistry >> reset [
-	locks removeAll
+	locks := Dictionary 
 ]
 
 { #category : #accessing }

--- a/src/OmniBase/ODBLockRegistry.class.st
+++ b/src/OmniBase/ODBLockRegistry.class.st
@@ -67,8 +67,21 @@ ODBLockRegistry >> checkRemoval [
 ]
 
 { #category : #testing }
-ODBLockRegistry >> hasLockFor: anODBObjectID [ 
-	^ locks includesKey: anODBObjectID 
+ODBLockRegistry >> hasForeignLockFor: anODBObjectID transaction: aTransaction [
+	"test if there is a lock that is present and that belongs to aTransaction"
+	^ locks 
+		at: anODBObjectID 
+		ifPresent: [ :lock | (lock transaction = aTransaction) not  ]
+		ifAbsent: [ false ]
+]
+
+{ #category : #testing }
+ODBLockRegistry >> hasLockFor: anODBObjectID transaction: aTransaction [
+	"test if there is a lock that is present and that belongs to aTransaction"
+	^ locks 
+		at: anODBObjectID 
+		ifPresent: [ :lock | (lock transaction = aTransaction) not  ]
+		ifAbsent: [ false ]
 ]
 
 { #category : #initialization }

--- a/src/OmniBase/ODBLockRegistry.class.st
+++ b/src/OmniBase/ODBLockRegistry.class.st
@@ -36,6 +36,18 @@ ODBLockRegistry class >> registries [
 	^ registries 
 ]
 
+{ #category : #'as yet unclassified' }
+ODBLockRegistry class >> remove: aRegistry [ 
+	^ registries removeKey: aRegistry path 
+	
+]
+
+{ #category : #'as yet unclassified' }
+ODBLockRegistry class >> removePath: aString [ 
+	^ registries removeKey: aString 
+	
+]
+
 { #category : #initialization }
 ODBLockRegistry class >> reset [ 
 	registries := Dictionary new
@@ -46,6 +58,12 @@ ODBLockRegistry >> addLock: anODBObjectLock [
 	locks 
 		at: anODBObjectLock objectID 
 		put: anODBObjectLock 
+]
+
+{ #category : #'as yet unclassified' }
+ODBLockRegistry >> checkRemoval [
+	locks isEmpty ifTrue: [ 
+		self remove ]
 ]
 
 { #category : #testing }
@@ -76,20 +94,27 @@ ODBLockRegistry >> locksWithTransaction: aTransaction [
 ]
 
 { #category : #accessing }
+ODBLockRegistry >> path [
+
+	^ path
+]
+
+{ #category : #accessing }
 ODBLockRegistry >> path: aFileReference [ 
 	path := aFileReference 
 ]
 
 { #category : #removing }
 ODBLockRegistry >> remove [
-	
+	self class remove: self
 ]
 
 { #category : #removing }
 ODBLockRegistry >> removeLock: anODBObjectLock [ 
 	locks 
 		removeKey: anODBObjectLock objectID 
-		ifAbsent: [  ]
+		ifAbsent: [  ].
+	self checkRemoval 
 ]
 
 { #category : #initialization }

--- a/src/OmniBase/ODBLockRegistry.class.st
+++ b/src/OmniBase/ODBLockRegistry.class.st
@@ -36,6 +36,11 @@ ODBLockRegistry class >> registries [
 	^ registries 
 ]
 
+{ #category : #initialization }
+ODBLockRegistry class >> reset [ 
+	registries := Dictionary new
+]
+
 { #category : #adding }
 ODBLockRegistry >> addLock: anODBObjectLock [ 
 	locks 

--- a/src/OmniBase/ODBLockRegistry.class.st
+++ b/src/OmniBase/ODBLockRegistry.class.st
@@ -117,13 +117,6 @@ ODBLockRegistry >> lockAt: key put: aLock [
 	^ true
 ]
 
-{ #category : #'as yet unclassified' }
-ODBLockRegistry >> locksWithTransaction: aTransaction [ 
-	^ mutex critical: [
-		locks values 
-			select: [ :lock | lock transaction = aTransaction ] ]
-]
-
 { #category : #accessing }
 ODBLockRegistry >> path [
 

--- a/src/OmniBase/ODBLockRegistry.class.st
+++ b/src/OmniBase/ODBLockRegistry.class.st
@@ -55,20 +55,10 @@ ODBLockRegistry class >> reset [
 ]
 
 { #category : #adding }
-ODBLockRegistry >> addLock: anODBObjectLock [ 
-	| key lock |
-	key := anODBObjectLock registryKey.
-	lock := locks 
-		at: key
-		ifPresent: [ :l |
-			(l transaction = anODBObjectLock transaction) 
-				ifFalse: [ ^ false ].
-			(l objectID = anODBObjectLock objectID) 
-			ifTrue: [ ^ true ] ].
-	locks 
-		at: key 
-		put: anODBObjectLock.
-	^ true
+ODBLockRegistry >> addLock: aKeyLock [ 
+	^ self 
+		lockAt: aKeyLock lockRegistryKey 
+		put: aKeyLock 
 ]
 
 { #category : #'as yet unclassified' }
@@ -78,12 +68,17 @@ ODBLockRegistry >> checkRemoval [
 ]
 
 { #category : #testing }
-ODBLockRegistry >> hasForeignLockFor: anODBObjectID transaction: aTransaction [
+ODBLockRegistry >> hasForeignLockFor: aTransactionObject transaction: aTransaction [
 	"test if there is a lock that is present and that belongs to aTransaction"
 	^ locks 
-		at: anODBObjectID registryKey
+		at: aTransactionObject lockRegistryKey 
 		ifPresent: [ :lock | (lock transaction = aTransaction) not  ]
 		ifAbsent: [ false ]
+]
+
+{ #category : #testing }
+ODBLockRegistry >> hasKeyLockOn: aBtreeDictionary key: key [ 
+	^ locks includesKey: (aBtreeDictionary lockRegistryKeyAt: key)
 ]
 
 { #category : #initialization }
@@ -97,9 +92,23 @@ ODBLockRegistry >> isEmpty [
 	^ locks isEmpty
 ]
 
-{ #category : #accessing }
-ODBLockRegistry >> locks [
-	^ locks
+{ #category : #testing }
+ODBLockRegistry >> keyLockOn: aBtreeDictionary key: key ifAbsent: aBlock [
+	^ locks 
+		at: (aBtreeDictionary lockRegistryKeyAt: key) 
+		ifAbsent: aBlock
+]
+
+{ #category : #adding }
+ODBLockRegistry >> lockAt: key put: aLock [ 
+	locks 
+		at: key
+		ifPresent: [ :lock |
+			^ lock isSameTransaction: aLock transaction ].
+	locks 
+		at: key 
+		put: aLock.
+	^ true
 ]
 
 { #category : #'as yet unclassified' }
@@ -127,7 +136,7 @@ ODBLockRegistry >> remove [
 { #category : #removing }
 ODBLockRegistry >> removeLock: anODBObjectLock [ 
 	locks 
-		removeKey: anODBObjectLock registryKey 
+		removeKey: anODBObjectLock lockRegistryKey 
 		ifAbsent: [  ].
 	self checkRemoval 
 ]

--- a/src/OmniBase/ODBLockRegistry.class.st
+++ b/src/OmniBase/ODBLockRegistry.class.st
@@ -1,3 +1,13 @@
+"
+ODBLockRegistry
+=============== 
+
+ODBLockRegistry is a central instance that coordinates locks across transaction boundaries. When Omnibase was created it was developped on an ancient windows platform. On this platform a lock to a file was always exclusive so no other attempt to access that same file was successful. A big part of the implementation relies on that.
+
+In the context *nix systems this did not work because the semanics for file locks are different. In *nix system a file lock only protects file access between different OS processes. Within the same OS process these locks are not doing anything because it is assumed that the program that runs in a process has better ways to coordinate concurrent access to files.   
+
+ODBLockRegistry closes this gap by providing a central way of managing locks. A Omnibase is contained in a file directory. Concurrent access is therefor only to be managed within one of this directories. Therefor all instances of Omnibase receive the same instance of a lock registry. The Omnibase instance itself registers each lock it acquires in the registry and this way we can detect early lock conflicts
+"
 Class {
 	#name : #ODBLockRegistry,
 	#superclass : #Object,
@@ -15,6 +25,9 @@ Class {
 { #category : #'as yet unclassified' }
 ODBLockRegistry class >> forPath: aString [ 
 	| path |
+	"locks are managed per omnibase path on disk. So every instance of 
+	OmniBase that access the same path gets the same lock registry to 
+	manage conflicts across transaction boundaries"
 	path := aString asFileReference asAbsolute.
 	^ registries 
 		at: path 

--- a/src/OmniBase/ODBLockRegistry.class.st
+++ b/src/OmniBase/ODBLockRegistry.class.st
@@ -38,8 +38,9 @@ ODBLockRegistry class >> registries [
 
 { #category : #'as yet unclassified' }
 ODBLockRegistry class >> remove: aRegistry [ 
-	^ registries removeKey: aRegistry path 
-	
+	^ registries 
+		removeKey: aRegistry path 
+		ifAbsent: [ ] 
 ]
 
 { #category : #'as yet unclassified' }
@@ -55,9 +56,19 @@ ODBLockRegistry class >> reset [
 
 { #category : #adding }
 ODBLockRegistry >> addLock: anODBObjectLock [ 
+	| key lock |
+	key := anODBObjectLock registryKey.
+	lock := locks 
+		at: key
+		ifPresent: [ :l |
+			(l transaction = anODBObjectLock transaction) 
+				ifFalse: [ ^ false ].
+			(l objectID = anODBObjectLock objectID) 
+			ifTrue: [ ^ true ] ].
 	locks 
-		at: anODBObjectLock objectID 
-		put: anODBObjectLock 
+		at: key 
+		put: anODBObjectLock.
+	^ true
 ]
 
 { #category : #'as yet unclassified' }
@@ -70,16 +81,7 @@ ODBLockRegistry >> checkRemoval [
 ODBLockRegistry >> hasForeignLockFor: anODBObjectID transaction: aTransaction [
 	"test if there is a lock that is present and that belongs to aTransaction"
 	^ locks 
-		at: anODBObjectID 
-		ifPresent: [ :lock | (lock transaction = aTransaction) not  ]
-		ifAbsent: [ false ]
-]
-
-{ #category : #testing }
-ODBLockRegistry >> hasLockFor: anODBObjectID transaction: aTransaction [
-	"test if there is a lock that is present and that belongs to aTransaction"
-	^ locks 
-		at: anODBObjectID 
+		at: anODBObjectID registryKey
 		ifPresent: [ :lock | (lock transaction = aTransaction) not  ]
 		ifAbsent: [ false ]
 ]
@@ -125,7 +127,7 @@ ODBLockRegistry >> remove [
 { #category : #removing }
 ODBLockRegistry >> removeLock: anODBObjectLock [ 
 	locks 
-		removeKey: anODBObjectLock objectID 
+		removeKey: anODBObjectLock registryKey 
 		ifAbsent: [  ].
 	self checkRemoval 
 ]

--- a/src/OmniBase/ODBLockRegistry.class.st
+++ b/src/OmniBase/ODBLockRegistry.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #ODBLockRegistry,
+	#superclass : #Object,
+	#category : #'OmniBase-Base'
+}
+
+{ #category : #'as yet unclassified' }
+ODBLockRegistry class >> registeredPaths [
+	self shouldBeImplemented.
+]

--- a/src/OmniBase/ODBLockRegistry.class.st
+++ b/src/OmniBase/ODBLockRegistry.class.st
@@ -1,10 +1,92 @@
 Class {
 	#name : #ODBLockRegistry,
 	#superclass : #Object,
+	#instVars : [
+		'path',
+		'locks'
+	],
+	#classInstVars : [
+		'registries'
+	],
 	#category : #'OmniBase-Base'
 }
 
 { #category : #'as yet unclassified' }
+ODBLockRegistry class >> forPath: aString [ 
+	| path |
+	path := aString asFileReference asAbsolute.
+	^ registries 
+		at: path 
+		ifAbsentPut: [ 
+			self new path: path  ] 
+]
+
+{ #category : #initialization }
+ODBLockRegistry class >> initialize [ 
+	registries := WeakValueDictionary new
+]
+
+{ #category : #'as yet unclassified' }
 ODBLockRegistry class >> registeredPaths [
-	self shouldBeImplemented.
+	^ self registries keys
+]
+
+{ #category : #accessing }
+ODBLockRegistry class >> registries [ 
+	^ registries 
+]
+
+{ #category : #adding }
+ODBLockRegistry >> addLock: anODBObjectLock [ 
+	locks 
+		at: anODBObjectLock objectID 
+		put: anODBObjectLock 
+]
+
+{ #category : #testing }
+ODBLockRegistry >> hasLockFor: anODBObjectID [ 
+	^ locks includesKey: anODBObjectID 
+]
+
+{ #category : #initialization }
+ODBLockRegistry >> initialize [ 
+	super initialize.
+	locks := Dictionary new
+]
+
+{ #category : #testing }
+ODBLockRegistry >> isEmpty [
+	^ locks isEmpty
+]
+
+{ #category : #accessing }
+ODBLockRegistry >> locks [
+	^ locks
+]
+
+{ #category : #accessing }
+ODBLockRegistry >> path: aFileReference [ 
+	path := aFileReference 
+]
+
+{ #category : #removing }
+ODBLockRegistry >> remove [
+	
+]
+
+{ #category : #removing }
+ODBLockRegistry >> removeLock: anODBObjectLock [ 
+	locks 
+		removeKey: anODBObjectLock objectID 
+		ifAbsent: [  ]
+]
+
+{ #category : #initialization }
+ODBLockRegistry >> reset [
+	locks removeAll
+]
+
+{ #category : #accessing }
+ODBLockRegistry >> size [ 
+	^ locks size
 ]

--- a/src/OmniBase/ODBObjectID.class.st
+++ b/src/OmniBase/ODBObjectID.class.st
@@ -105,6 +105,29 @@ ODBObjectID >> loadFromStream: aStream [
     self fromBytes: bytes at: 1
 ]
 
+{ #category : #'as yet unclassified' }
+ODBObjectID >> lockRegistryKey [
+	^ String streamContents: [ :stream |
+		self lockRegistryKeyOn: stream ]
+]
+
+{ #category : #'as yet unclassified' }
+ODBObjectID >> lockRegistryKeyAt: aKey [
+	^ String streamContents: [ :stream |
+		self lockRegistryKeyOn: stream.
+		stream 
+			<< ':'
+			<< aKey asInteger asString ]
+]
+
+{ #category : #'as yet unclassified' }
+ODBObjectID >> lockRegistryKeyOn: aStream [
+	aStream 
+		<< containerID asString 
+		<< ':'
+		<< index asString
+]
+
 { #category : #public }
 ODBObjectID >> printOn: aStream [ 
 	super printOn: aStream.
@@ -121,11 +144,6 @@ ODBObjectID >> putBytesTo: bytes at: pos [
 	bytes
 		odbLongAt: pos put: index;
 		at: pos + 3 put: containerID
-]
-
-{ #category : #'as yet unclassified' }
-ODBObjectID >> registryKey [
-	^ containerID asString , ':', index asString
 ]
 
 { #category : #'public/load/store' }

--- a/src/OmniBase/ODBObjectID.class.st
+++ b/src/OmniBase/ODBObjectID.class.st
@@ -123,6 +123,11 @@ ODBObjectID >> putBytesTo: bytes at: pos [
 		at: pos + 3 put: containerID
 ]
 
+{ #category : #'as yet unclassified' }
+ODBObjectID >> registryKey [
+	^ containerID asString , ':', index asString
+]
+
 { #category : #'public/load/store' }
 ODBObjectID >> storeOnStream: aStream [
 

--- a/src/OmniBase/ODBObjectLock.class.st
+++ b/src/OmniBase/ODBObjectLock.class.st
@@ -26,11 +26,6 @@ ODBObjectLock >> storeOnStream: aStream [
         aStream putLong: lockID
 ]
 
-{ #category : #accessing }
-ODBObjectLock >> transaction [
-	^ transaction 
-]
-
 { #category : #'public/unclassified' }
 ODBObjectLock >> unlock [
 

--- a/src/OmniBase/ODBObjectLock.class.st
+++ b/src/OmniBase/ODBObjectLock.class.st
@@ -19,11 +19,6 @@ ODBObjectLock >> loadFromStream: aStream [
     lockID := aStream getLong
 ]
 
-{ #category : #'as yet unclassified' }
-ODBObjectLock >> registryKeyOn: aStream [ 
-	aStream << objectID registryKey 
-]
-
 { #category : #'public/load/store' }
 ODBObjectLock >> storeOnStream: aStream [
 

--- a/src/OmniBase/ODBObjectLock.class.st
+++ b/src/OmniBase/ODBObjectLock.class.st
@@ -19,6 +19,11 @@ ODBObjectLock >> loadFromStream: aStream [
     lockID := aStream getLong
 ]
 
+{ #category : #'as yet unclassified' }
+ODBObjectLock >> registryKeyOn: aStream [ 
+	aStream << objectID registryKey 
+]
+
 { #category : #'public/load/store' }
 ODBObjectLock >> storeOnStream: aStream [
 

--- a/src/OmniBase/ODBTerminatedTransaction.class.st
+++ b/src/OmniBase/ODBTerminatedTransaction.class.st
@@ -11,7 +11,8 @@ ODBTerminatedTransaction >> start [
 
     transactionManager transactionStart: self.
     versionDescriptor versionNumber: transactionFile versionNumber.
-    locks := transactionFile locks
+    transactionFile locks do: [ :lock |
+		self addLock: lock ]
 ]
 
 { #category : #'private/accessing' }

--- a/src/OmniBase/ODBTransaction.class.st
+++ b/src/OmniBase/ODBTransaction.class.st
@@ -51,8 +51,7 @@ ODBTransaction >> basicAbort [
 								[:each | 
 								each
 									transaction: self;
-									unlock.
-								lockRegistry removeLock: each]].
+									unlock ]].
 			transactionManager transactionAborted: self.
 			client transactionRemove: self].
 	objects := nil.

--- a/src/OmniBase/ODBTransaction.class.st
+++ b/src/OmniBase/ODBTransaction.class.st
@@ -5,7 +5,6 @@ Class {
 		'cacheMutex',
 		'client',
 		'dbConnection',
-		'locks',
 		'objectIndex',
 		'objects',
 		'transactionFile',
@@ -36,23 +35,24 @@ ODBTransaction >> abort [
 ODBTransaction >> basicAbort [
 	"Private - Abort transaction. After aborting it, it can not be used anymore."
 
-	| changes |
+	| changes locks |
 	dbConnection isNil 
 		ifFalse: 
-			[lockRegistry isEmpty 
-				ifFalse: 
-					[(changes := transactionFile recovery) isNil 
-						ifFalse: 
-							[changes
-								transaction: self;
-								rollback.
-							transactionFile recovery: nil].
-					(lockRegistry locksWithTransaction: self) do: 
-							[:each | 
-							each
-								transaction: self;
-								unlock.
-							lockRegistry removeLock: each]].
+			[	locks := lockRegistry locksWithTransaction: self.
+				locks isEmpty 
+					ifFalse: 
+						[(changes := transactionFile recovery) isNil 
+							ifFalse: 
+								[changes
+									transaction: self;
+									rollback.
+								transactionFile recovery: nil].
+						locks do: 
+								[:each | 
+								each
+									transaction: self;
+									unlock.
+								lockRegistry removeLock: each]].
 			transactionManager transactionAborted: self.
 			client transactionRemove: self].
 	objects := nil.

--- a/src/OmniBase/ODBTransaction.class.st
+++ b/src/OmniBase/ODBTransaction.class.st
@@ -52,7 +52,7 @@ ODBTransaction >> basicAbort [
 								each
 									transaction: self;
 									unlock.
-								lockRegistry removeLock: each ]].
+								lockRegistry removeLock: each]].
 			transactionManager transactionAborted: self.
 			client transactionRemove: self].
 	objects := nil.
@@ -235,6 +235,11 @@ ODBTransaction >> isReadOnly [
 		"Answer <true> if this is a read-only transaction."
 
 	^false
+]
+
+{ #category : #accessing }
+ODBTransaction >> locks [
+	^ lockRegistry locksWithTransaction: self
 ]
 
 { #category : #public }

--- a/src/OmniBase/ODBTransaction.class.st
+++ b/src/OmniBase/ODBTransaction.class.st
@@ -35,24 +35,21 @@ ODBTransaction >> abort [
 ODBTransaction >> basicAbort [
 	"Private - Abort transaction. After aborting it, it can not be used anymore."
 
-	| changes locks |
+	| changes |
 	dbConnection isNil 
-		ifFalse: 
-			[	locks := lockRegistry locksWithTransaction: self.
-				locks isEmpty 
-					ifFalse: 
-						[(changes := transactionFile recovery) isNil 
-							ifFalse: 
-								[changes
-									transaction: self;
-									rollback.
-								transactionFile recovery: nil].
-						locks do: 
-								[:each | 
-								each
-									transaction: self;
-									unlock.
-								lockRegistry removeLock: each]].
+		ifFalse: [	
+			self locks ifNotEmpty: [ :locks |
+				(changes := transactionFile recovery) isNil 
+						ifFalse: [
+							changes
+								transaction: self;
+								rollback.
+							transactionFile recovery: nil].
+					locks do: [:each | 
+						each
+							transaction: self;
+							unlock.
+						lockRegistry removeLock: each]].
 			transactionManager transactionAborted: self.
 			client transactionRemove: self].
 	objects := nil.

--- a/src/OmniBase/ODBTransaction.class.st
+++ b/src/OmniBase/ODBTransaction.class.st
@@ -51,7 +51,8 @@ ODBTransaction >> basicAbort [
 								[:each | 
 								each
 									transaction: self;
-									unlock ]].
+									unlock.
+								lockRegistry removeLock: each ]].
 			transactionManager transactionAborted: self.
 			client transactionRemove: self].
 	objects := nil.

--- a/src/OmniBase/ODBTransaction.class.st
+++ b/src/OmniBase/ODBTransaction.class.st
@@ -10,7 +10,8 @@ Class {
 		'transactionFile',
 		'transactionManager',
 		'versionDescriptor',
-		'lockRegistry'
+		'lockRegistry',
+		'locks'
 	],
 	#category : #'OmniBase-Transaction'
 }
@@ -38,18 +39,16 @@ ODBTransaction >> basicAbort [
 	| changes |
 	dbConnection isNil 
 		ifFalse: [	
-			self locks ifNotEmpty: [ :locks |
+			 locks ifNotEmpty: [
 				(changes := transactionFile recovery) isNil 
 						ifFalse: [
 							changes
 								transaction: self;
 								rollback.
 							transactionFile recovery: nil].
-					locks do: [:each | 
-						each
-							transaction: self;
-							unlock.
-						lockRegistry removeLock: each]].
+				locks do: [:each | 
+					each unlock.
+					lockRegistry removeLock: each ]].
 			transactionManager transactionAborted: self.
 			client transactionRemove: self].
 	objects := nil.
@@ -236,7 +235,7 @@ ODBTransaction >> isReadOnly [
 
 { #category : #accessing }
 ODBTransaction >> locks [
-	^ lockRegistry locksWithTransaction: self
+	^ locks
 ]
 
 { #category : #public }

--- a/src/OmniBase/ODBTransaction.class.st
+++ b/src/OmniBase/ODBTransaction.class.st
@@ -10,7 +10,8 @@ Class {
 		'objects',
 		'transactionFile',
 		'transactionManager',
-		'versionDescriptor'
+		'versionDescriptor',
+		'lockRegistry'
 	],
 	#category : #'OmniBase-Transaction'
 }
@@ -44,7 +45,7 @@ ODBTransaction >> basicAbort [
 	| changes |
 	dbConnection isNil 
 		ifFalse: 
-			[locks isNil 
+			[lockRegistry isEmpty 
 				ifFalse: 
 					[(changes := transactionFile recovery) isNil 
 						ifFalse: 
@@ -52,11 +53,12 @@ ODBTransaction >> basicAbort [
 								transaction: self;
 								rollback.
 							transactionFile recovery: nil].
-					locks do: 
+					lockRegistry locks do: 
 							[:each | 
 							each
 								transaction: self;
-								unlock]].
+								unlock.
+							lockRegistry removeLock: each]].
 			transactionManager transactionAborted: self.
 			client transactionRemove: self].
 	objects := nil.
@@ -316,7 +318,8 @@ ODBTransaction >> root [
 ODBTransaction >> setClient: aClient environment: anOmniBase [ 
 	client := aClient.
 	dbConnection := anOmniBase.
-	transactionManager := dbConnection transactionManager
+	transactionManager := dbConnection transactionManager.
+	lockRegistry := dbConnection lockRegistry
 ]
 
 { #category : #'private/accessing' }

--- a/src/OmniBase/ODBTransactionManager.class.st
+++ b/src/OmniBase/ODBTransactionManager.class.st
@@ -130,7 +130,6 @@ ODBTransactionManager >> transactionReferenceAt: index [
 { #category : #'public/unclassified' }
 ODBTransactionManager >> transactionStart: aTransaction [
                 "Set transaction version descriptor upon transaction start."
-
         aTransaction versionDescriptor: versionControl versionDescriptor copy
 ]
 

--- a/src/OmniBase/ODBTransactionObject.class.st
+++ b/src/OmniBase/ODBTransactionObject.class.st
@@ -41,7 +41,7 @@ ODBTransactionObject >> lock [
 	lockObject isNil 
 		ifTrue: 
 			[
-			(transaction hasLockFor: holder objectID) ifTrue: [ ^ false ].
+			(transaction hasForeignLockFor: holder objectID) ifTrue: [ ^ false ].
 			(lockID := transaction lockID) isNil ifTrue: [^false].
 			transaction isGlobalLocked ifTrue: [^true].
 			lockObj := ODBObjectLock new.

--- a/src/OmniBase/ODBTransactionObject.class.st
+++ b/src/OmniBase/ODBTransactionObject.class.st
@@ -41,7 +41,7 @@ ODBTransactionObject >> lock [
 	lockObject isNil 
 		ifTrue: 
 			[
-			(transaction hasForeignLockFor: holder objectID) ifTrue: [ ^ false ].
+			(transaction hasForeignLockFor: self) ifTrue: [ ^ false ].
 			(lockID := transaction lockID) isNil ifTrue: [^false].
 			transaction isGlobalLocked ifTrue: [^true].
 			lockObj := ODBObjectLock new.
@@ -55,6 +55,11 @@ ODBTransactionObject >> lock [
 					^false].
 			lockObject := lockObj].
 	^true
+]
+
+{ #category : #'as yet unclassified' }
+ODBTransactionObject >> lockRegistryKey [
+	^ self objectID lockRegistryKey 
 ]
 
 { #category : #public }

--- a/src/OmniBase/ODBTransactionObject.class.st
+++ b/src/OmniBase/ODBTransactionObject.class.st
@@ -46,7 +46,9 @@ ODBTransactionObject >> lock [
 	| lockID lockObj |
 	lockObject isNil 
 		ifTrue: 
-			[(lockID := transaction lockID) isNil ifTrue: [^false].
+			[
+			(transaction hasLockFor: holder objectID) ifTrue: [ ^ false ].
+			(lockID := transaction lockID) isNil ifTrue: [^false].
 			transaction isGlobalLocked ifTrue: [^true].
 			lockObj := ODBObjectLock new.
 			lockObj

--- a/src/OmniBase/OmniBase.class.st
+++ b/src/OmniBase/OmniBase.class.st
@@ -294,6 +294,7 @@ OmniBase >> close [
 			transactionManager := nil].
 	lockRegistry notNil 
 		ifTrue: [ 
+			lockRegistry checkRemoval.
 			lockRegistry := nil ].
 	self class remove: self
 ]

--- a/src/OmniBase/OmniBase.class.st
+++ b/src/OmniBase/OmniBase.class.st
@@ -6,7 +6,8 @@ Class {
 		'objectManager',
 		'classManager',
 		'clientManager',
-		'transactionManager'
+		'transactionManager',
+		'lockRegistry'
 	],
 	#classInstVars : [
 		'currentTransaction',
@@ -291,6 +292,9 @@ OmniBase >> close [
 		ifTrue: 
 			[transactionManager close.
 			transactionManager := nil].
+	lockRegistry notNil 
+		ifTrue: [ 
+			lockRegistry := nil ].
 	self class remove: self
 ]
 
@@ -331,6 +335,7 @@ OmniBase >> createOn: dirName [
 	objectManager := self objectManager createOn: self.
 	transactionManager := self transactionManager createOn: self.
 	clientManager := self clientManager createOn: self.
+	lockRegistry := ODBLockRegistry forPath: dirName.
 	self opened.
 	clientManager localClient makeRootObject] 
 			ifCurtailed: [self close]
@@ -408,6 +413,11 @@ OmniBase >> localClient [
 ]
 
 { #category : #accessing }
+OmniBase >> lockRegistry [
+	^ lockRegistry
+]
+
+{ #category : #accessing }
 OmniBase >> newBTreeDictionary: keySize [
 
 	^self class newBTreeDictionary: keySize
@@ -455,7 +465,6 @@ OmniBase >> newReadOnlyTransaction [
 
 { #category : #accessing }
 OmniBase >> newTransaction [
-
     ^clientManager localClient newTransaction
 ]
 
@@ -507,6 +516,7 @@ OmniBase >> openOn: dirName [
 	objectManager := self objectManager openOn: self.
 	transactionManager := self transactionManager openOn: self.
 	clientManager := self clientManager openOn: self.
+	lockRegistry := ODBLockRegistry forPath: dirName.
 	self opened] 
 			ifCurtailed: [self close].
 	self freeDiskSpace < 5242880 ifTrue: [OmniBase warningMessage: 'Low disk space !']


### PR DESCRIPTION
The original omnibase relied locking completely on filesystem locking. In the windows systems back then locking was always mandatory, meaning the full file was locked. Early users of omnibase fiddled with the mandatory locking option in linux systems.
The semantics of fcntl() in *nix systems is that it is capable of locking resources between processes. This means two processes locking the same resource will fail. But the semantics are as well that within a process you cannot have that lock because it is expected that the process knows better how to organize concurrency.
This PR is an attempt to move locks from within a transaction to a global image structure. This can then be checked and locking conflicts can be detected before going to disk. This will then also work if multiple omnibase instances trying to lock the same object. The management is per filesystem path because locking refers to all objects below the root directory of a single omnibase