### PR TITLE
Cleanup ODBStream other Platforms

### DIFF
--- a/src/OmniBase/ODBFileStream.class.st
+++ b/src/OmniBase/ODBFileStream.class.st
@@ -16,8 +16,6 @@ ODBFileStream class >> accessModeReadOnly [
 
 { #category : #'create/open flags' }
 ODBFileStream class >> accessModeReadWrite [
-
-	
 	^#accessModeReadWrite
 ]
 
@@ -28,8 +26,6 @@ ODBFileStream class >> cacheModeAtomicWrite [
 
 { #category : #'create/open flags' }
 ODBFileStream class >> createModeCreateAlways [
-
-	
 	^#createModeCreateAlways
 ]
 
@@ -94,10 +90,7 @@ ODBFileStream class >> createOn: pathName createMode: createMode accessMode: acc
 				['Win32'] -> [ODBWin32FileStream].
 				}
 			otherwise: 
-				[self notify: 'File sharing & locking not implemented for this platform'.
-				^ self 
-					createWithoutSharingAndLockingOn: pathName 
-					accessMode: accessMode].
+				[^self error: 'Platform not Supported'].
 			
 	^ fileStreamClass
 		createOn: pathName 
@@ -105,14 +98,6 @@ ODBFileStream class >> createOn: pathName createMode: createMode accessMode: acc
 		accessMode: accessMode 
 		shareMode: shareMode 
 		cacheMode: cacheMode
-]
-
-{ #category : #'create/open' }
-ODBFileStream class >> createWithoutSharingAndLockingOn: pathName accessMode: accessMode [
-	| stream  |
-	stream := FileStream fileNamed: pathName.
-	accessMode = #accessModeReadOnly ifTrue: [stream readOnly].
-	^self new openOn: pathName fileHandle: stream.
 ]
 
 { #category : #'directory operations' }
@@ -136,30 +121,6 @@ ODBFileStream class >> exists: fileName [
 
 	
 	^ fileName asFileReference exists
-]
-
-{ #category : #locking }
-ODBFileStream class >> lockAt: pos length: length pathName: pathName fileHandle: fileHandle seekingMutex: seekingMutex position: position [
-		"Lock portion of file starting at position pos.
-		Answer <true> if successfull, <false> otherwise."
-
-	| result lockInterval fileLocks |
-	lockInterval := 0 @ pos extent: 1 @ length.
-	seekingMutex critical: [
-	self lockingMutex critical: [
-	(fileLocks := locks at: pathName ifAbsent: []) isNil
-		ifFalse: [fileLocks do: [:each | (each first intersects: lockInterval) ifTrue: [^false]]].
-	result := true.
-	[ fileHandle position: pos; lock: true for: length ]
-		on: Error
-		do: [ :error | result := false ].
-	result
-		ifTrue: [
-			fileLocks isNil ifTrue: [locks at: pathName put: (fileLocks := OrderedCollection new)].
-			fileLocks add: (Array with: lockInterval with: fileHandle) ].
-	fileHandle position: position.
-	]].
-	^result
 ]
 
 { #category : #locking }
@@ -241,33 +202,6 @@ ODBFileStream class >> shareModeShareRead [
 { #category : #'create/open flags' }
 ODBFileStream class >> shareModeShareWrite [
 	^#shareModeShareWrite
-]
-
-{ #category : #locking }
-ODBFileStream class >> unlockAt: pos length: length pathName: pathName fileHandle: fileHandle seekingMutex: seekingMutex position: position [
-		"Unlock portion of file at position pos. 
-		Answer <true> if successfull, <false> if failed."
-
-	| result lockInterval newFileLocks fileLocks |
-	seekingMutex critical: [
-	self lockingMutex critical: [
-	(fileLocks := locks at: pathName ifAbsent: []) isNil ifTrue: [^false].
-	lockInterval := 0 @ pos extent: 1 @ length.
-	newFileLocks := OrderedCollection new.
-	fileLocks do: [:each |
-		((each first intersects: lockInterval) and: [each last == fileHandle])
-			ifFalse: [newFileLocks add: each]
-			ifTrue: [each first = lockInterval ifFalse: [self error: 'Partial unlock is not allowed']]].
-	newFileLocks isEmpty
-		ifTrue: [locks removeKey: pathName]
-		ifFalse: [locks at: pathName put: newFileLocks].
-	result := true.
-	[ fileHandle position: pos; lock: false for: length ]
-		on: Error
-		do: [ :error | result := false ].
-	fileHandle position: position.
-	]].
-	^result
 ]
 
 { #category : #public }
@@ -447,13 +381,14 @@ ODBFileStream >> getWord [
 
 { #category : #public }
 ODBFileStream >> lockAt: pos length: length [
-		"Lock portion of file starting at position pos. 
-		Answer <true> if successfull, <false> if failed.
-		Also sets an internal lock to prevent setting lock twice.
-		Unix style fcntl locking will answer true if a lock is set twice.
-		For OmniBase this is not allowed."
 
-	^self class lockAt: pos length: length pathName: pathName fileHandle: fileHandle seekingMutex: mutex position: position
+	"Lock portion of file starting at position pos. 
+	Answer <true> if successfull, <false> if failed.
+	Also sets an internal lock to prevent setting lock twice.
+	Unix style fcntl locking will answer true if a lock is set twice.
+	For OmniBase this is not allowed."
+
+	^ self subclassResponsibility
 ]
 
 { #category : #public }
@@ -555,8 +490,8 @@ ODBFileStream >> truncate: anInteger [
 
 { #category : #public }
 ODBFileStream >> unlockAt: pos length: length [
-		"Unlock portion of file at position pos.
-		Answer <true> if successfull, <false> if failed."
+	"Unlock portion of file at position pos.
+	Answer <true> if successfull, <false> if failed."
 
-	^self class unlockAt: pos length: length pathName: pathName fileHandle: fileHandle seekingMutex: mutex position: position
+	self subclassResponsibility
 ]

--- a/src/OmniBase/ODBMacFileStream.class.st
+++ b/src/OmniBase/ODBMacFileStream.class.st
@@ -49,7 +49,7 @@ ODBMacFileStream class >> setShareMode: shareMode forFileStream: aFileStream [
 			[self shareModeShareAll] -> [nil].
 			[self shareModeShareRead] -> [false].
 			[self shareModeShareNone] -> [true].
-			[self shareModeShareWrite] -> [self halt] "don't know how to implement this on unix and it is currently unused"}.
+			[self shareModeShareWrite] -> [self error: 'not supported'] "don't know how to implement this on unix and it is currently unused"}.
 
 	flagState ifNotNil: [
 		(BSDFLock
@@ -77,9 +77,9 @@ ODBMacFileStream class >> streamCreationSelectorForMode: createMode [
 
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #public }
 ODBMacFileStream >> close [
-		"Close file associatied with receiver."
+	"Close file associatied with receiver."
 
 	fileHandle notNil ifTrue: [
 		BSDFLock 

--- a/src/OmniBase/ODBMemoryReadStream.class.st
+++ b/src/OmniBase/ODBMemoryReadStream.class.st
@@ -7,13 +7,13 @@ Class {
 	#category : #'OmniBase-Streams'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 ODBMemoryReadStream class >> createOn: bytes [
 
     ^self new createOn: bytes
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 ODBMemoryReadStream class >> readFrom: aStream [
 
     ^self new readFrom: aStream

--- a/src/OmniBase/ODBMemoryWriteStream.class.st
+++ b/src/OmniBase/ODBMemoryWriteStream.class.st
@@ -95,7 +95,7 @@ ODBMemoryWriteStream >> moveToNext [
 				do: [:i | (collections at: i) == current ifTrue: [^current := collections at: i + 1]]]
 ]
 
-{ #category : #public }
+{ #category : #accessing }
 ODBMemoryWriteStream >> position [
 	"Answer current position on stream."
 
@@ -109,7 +109,7 @@ ODBMemoryWriteStream >> position [
 	^size + position
 ]
 
-{ #category : #public }
+{ #category : #accessing }
 ODBMemoryWriteStream >> position: anInteger [ 
 	"Set current position on stream."
 
@@ -154,7 +154,7 @@ ODBMemoryWriteStream >> putBytesFrom: aByteCollection len: len [
 			position := position + len]
 ]
 
-{ #category : #public }
+{ #category : #accessing }
 ODBMemoryWriteStream >> size [
 	"Answer stream size."
 

--- a/src/OmniBase/ODBStream.class.st
+++ b/src/OmniBase/ODBStream.class.st
@@ -82,6 +82,16 @@ ODBStream >> getWord [
     ^self getByte bitOr: (self getByte bitShift: 8)
 ]
 
+{ #category : #accessing }
+ODBStream >> position [
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+ODBStream >> position: arg1 [ 
+	^ self subclassResponsibility
+]
+
 { #category : #public }
 ODBStream >> putBoolean: aBool [
 

--- a/src/OmniBase/ODBUnixFileStream.class.st
+++ b/src/OmniBase/ODBUnixFileStream.class.st
@@ -59,7 +59,7 @@ ODBUnixFileStream class >> setShareMode: shareMode forFileStream: aFileStream [
 			[self shareModeShareAll] -> [nil].
 			[self shareModeShareRead] -> [false].
 			[self shareModeShareNone] -> [true].
-			[self shareModeShareWrite] -> [self halt] "don't know how to implement this on unix and it is currently unused"}.
+			[self shareModeShareWrite] -> [self error: 'not supported'] "don't know how to implement this on unix and it is currently unused"}.
 
 	flagState ifNotNil: [
 		(FLock
@@ -87,9 +87,9 @@ ODBUnixFileStream class >> streamCreationSelectorForMode: createMode [
 
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #public }
 ODBUnixFileStream >> close [
-		"Close file associatied with receiver."
+	"Close file associatied with receiver."
 
 	fileHandle notNil ifTrue: [
 		FLock 
@@ -109,7 +109,7 @@ ODBUnixFileStream >> lockAt: pos length: length [
 		to: pos + length - 1
 ]
 
-{ #category : #accesing }
+{ #category : #public }
 ODBUnixFileStream >> size [
 	"the unix Squeak VM gives the wrong answer for #size"
 	| file |


### PR DESCRIPTION
This is a cleanup of ODBFileStream. It used to have (broken) support for non-Win, non-Unix, non-Mac.

This PR instead raises an Error and removes all the dead code.

in addititon:

- use error intead of halt
- some recategorizations 
- some subclassresponsibility


Fixes https://github.com/ApptiveGrid/MoniBase/issues/13
Fixes https://github.com/ApptiveGrid/MoniBase/issues/8