### PR TITLE
 ODBStream: do not manage position information

### DIFF
--- a/src/OmniBase/ODBFileStream.class.st
+++ b/src/OmniBase/ODBFileStream.class.st
@@ -288,8 +288,7 @@ ODBFileStream >> basicPosition: anInteger [
 	"Positiones stream to anInteger. Answer anInteger."
 
 	fileHandle position: anInteger.
-	^position := anInteger
-
+	^anInteger
 ]
 
 { #category : #public }
@@ -300,7 +299,6 @@ ODBFileStream >> basicPutBytesFrom: aByteArray len: length [
 		for: length)
 		= length ifFalse: [OmniBase signalError: 'Could not write the whole data'].
 	fileHandle flush.
-	position := position + length.
 	^self
 
 ]
@@ -403,7 +401,6 @@ ODBFileStream >> openOn: aString fileHandle: anIOAccessor [
 
 	pathName := aString.
 	fileHandle := anIOAccessor.
-	position := 0.
 	mutex := Semaphore forMutualExclusion.
 ]
 
@@ -416,7 +413,7 @@ ODBFileStream >> pathName [
 { #category : #public }
 ODBFileStream >> position [
 
-	^position
+	^fileHandle position
 ]
 
 { #category : #public }

--- a/src/OmniBase/ODBMemoryReadStream.class.st
+++ b/src/OmniBase/ODBMemoryReadStream.class.st
@@ -2,6 +2,7 @@ Class {
 	#name : #ODBMemoryReadStream,
 	#superclass : #ODBStream,
 	#instVars : [
+		'position',
 		'current'
 	],
 	#category : #'OmniBase-Streams'
@@ -17,6 +18,14 @@ ODBMemoryReadStream class >> createOn: bytes [
 ODBMemoryReadStream class >> readFrom: aStream [
 
     ^self new readFrom: aStream
+]
+
+{ #category : #public }
+ODBMemoryReadStream >> basicPosition: anInteger [
+	"Positiones stream to anInteger. Answer anInteger."
+
+	^position := anInteger
+
 ]
 
 { #category : #initializing }

--- a/src/OmniBase/ODBMemoryWriteStream.class.st
+++ b/src/OmniBase/ODBMemoryWriteStream.class.st
@@ -2,6 +2,7 @@ Class {
 	#name : #ODBMemoryWriteStream,
 	#superclass : #ODBStream,
 	#instVars : [
+		'position',
 		'collections',
 		'current',
 		'readLimit',
@@ -61,6 +62,13 @@ ODBMemoryWriteStream >> asStringObject [
 		with: coll
 		startingAt: 1.
 	^string
+]
+
+{ #category : #public }
+ODBMemoryWriteStream >> basicPosition: anInteger [
+	"Positiones stream to anInteger. Answer anInteger."
+
+	^position := anInteger
 ]
 
 { #category : #initialization }

--- a/src/OmniBase/ODBStream.class.st
+++ b/src/OmniBase/ODBStream.class.st
@@ -1,9 +1,6 @@
 Class {
 	#name : #ODBStream,
 	#superclass : #Object,
-	#instVars : [
-		'position'
-	],
 	#classInstVars : [
 		'locks',
 		'lockingMutex'


### PR DESCRIPTION
ODBStream managed a position variable that it had to keep in sync with the position of the BinaryFilesStream.

This PR:

- removes position from ODBStream, add it to the ODBMemory Streams
- #position now reports the position of the BinaryFilesStream


This PR does not yet rename the variable "fileHandle" to make reviewing easier