### PR TITLE
 57--ODBUnixFileStreamsize-has-VM-bug-Workaround

### DIFF
--- a/src/OmniBase-Tests/ODBDatabaseTest.class.st
+++ b/src/OmniBase-Tests/ODBDatabaseTest.class.st
@@ -49,11 +49,6 @@ ODBDatabaseTest >> benchmarkCommitNewObjects [
 	Transcript show: stream contents
 ]
 
-{ #category : #testing }
-ODBDatabaseTest >> expectedFailures [ 
-	^ #( testBackup )
-]
-
 { #category : #tests }
 ODBDatabaseTest >> testBackup [
 

--- a/src/OmniBase/BinaryFileStream.extension.st
+++ b/src/OmniBase/BinaryFileStream.extension.st
@@ -17,12 +17,6 @@ BinaryFileStream >> readInto: aByteArray startingAt: aNumber for: length [
 ]
 
 { #category : #'*OmniBase' }
-BinaryFileStream >> readOnlyCopy [
-
-	^ file openForRead
-]
-
-{ #category : #'*OmniBase' }
 BinaryFileStream >> writeFrom: aString startingAt: aNumber for: length [ 
 
 	^ File 

--- a/src/OmniBase/ODBMacFileStream.class.st
+++ b/src/OmniBase/ODBMacFileStream.class.st
@@ -100,18 +100,6 @@ ODBMacFileStream >> lockAt: pos length: length [
 ]
 
 { #category : #public }
-ODBMacFileStream >> size [
-	"the unix Squeak VM gives the wrong answer for #size"
-	| file |
-	fileHandle flush.
-	file := fileHandle readOnlyCopy.
-	^ [file size] ensure: [file close]
-	
-
-
-]
-
-{ #category : #public }
 ODBMacFileStream >> unlockAt: pos length: length [
 
 	^ BSDFLock 

--- a/src/OmniBase/ODBUnixFileStream.class.st
+++ b/src/OmniBase/ODBUnixFileStream.class.st
@@ -110,18 +110,6 @@ ODBUnixFileStream >> lockAt: pos length: length [
 ]
 
 { #category : #public }
-ODBUnixFileStream >> size [
-	"the unix Squeak VM gives the wrong answer for #size"
-	| file |
-	fileHandle flush.
-	file := fileHandle readOnlyCopy.
-	^ [file size] ensure: [file close]
-	
-
-
-]
-
-{ #category : #public }
 ODBUnixFileStream >> unlockAt: pos length: length [
 
 	^ FLock 


### PR DESCRIPTION
remove the VM bug workaround for #size.
Interestingly, after this #testBackup is green

fixes #57
fixes #11