### PR TITLE
[WIP] Fix gc and datafile locking

### DIFF
--- a/src/OmniBase/ODBContainer.class.st
+++ b/src/OmniBase/ODBContainer.class.st
@@ -228,8 +228,7 @@ ODBContainer >> lockDataFile [
 
     | currentSpace defaultSpace |
 
-    activeDataFile waitForAddingLockWhileWaitingDo:
-    [currentSpace := activeDataFile == dataFileA ifTrue: [0] ifFalse: [1].
+    currentSpace := activeDataFile == dataFileA ifTrue: [0] ifFalse: [1].
     defaultSpace := objectManager defaultObjectSpace.
     currentSpace == defaultSpace
         ifFalse:
@@ -242,7 +241,8 @@ openOn: self dataFileNameA].
                     [dataFileB isNil ifTrue: [dataFileB := ODBObjectStorage
 openOn: self dataFileNameB].
                     activeDataFile := dataFileB].
-            ^self lockDataFile]] 
+            ].
+	^ activeDataFile waitForAddingLock
 ]
 
 { #category : #public }

--- a/src/OmniBase/ODBFile.class.st
+++ b/src/OmniBase/ODBFile.class.st
@@ -173,17 +173,10 @@ ODBFile >> unlockAt: pos length: length [
 ODBFile >> waitForAddingLock [
 	"Lock file for writing at the end of the file."
 
-	^self 
-		waitForLockAt: 0
-		length: 1
-		whileWaitingDo: [(Delay forMilliseconds: 250) wait]
-]
+	^ self
+		waitForLockAt: 0 
+		length: 1 
 
-{ #category : #locking }
-ODBFile >> waitForAddingLockWhileWaitingDo: aBlock [
-        "Lock file for writing at the end of the file."
-
-    ^self waitForLockAt: 0 length: 1 whileWaitingDo: aBlock
 ]
 
 { #category : #public }
@@ -198,16 +191,10 @@ ODBFile >> waitForLockAt: pos length: length [
 
 { #category : #locking }
 ODBFile >> waitForLockAt: pos length: length whileWaitingDo: aBlock [
-		"Wait for lock at given position. 
-		Evaluate aBlock in each iteration."
-
-	"Dec, 2010. sas: evaluating code in each iteration while waiting sounds weird but whatever.
-	I think this was designed on the wrong assumption that the OS always will provide a false 
-	in the first try but what actually happens is that in win32 you always will 
-	get at least one false but in *nixes you don't do see that happening (which is totally reasonable).
-	BEWARE of stupid code relying on this stupid assumption (I've already patched #lockDataFile because of this)."
-	
 	| startTime currentTime |
+	"Wait for lock at given position. Evaluate aBlock in 
+	each iteration."
+
 	(stream lockAt: pos length: length) ifFalse: [
 		startTime := Time totalSeconds.
 		[stream lockAt: pos length: length] whileFalse: [

--- a/src/OmniBase/ODBFile.class.st
+++ b/src/OmniBase/ODBFile.class.st
@@ -183,10 +183,10 @@ ODBFile >> waitForAddingLock [
 ODBFile >> waitForLockAt: pos length: length [ 
 	"Wait for lock at given position."
 
-	^self 
+	^ self 
 		waitForLockAt: pos
 		length: length
-		whileWaitingDo: [(Delay forMilliseconds: 250) wait]
+		whileWaitingDo: [(Delay forMilliseconds: 10) wait]
 ]
 
 { #category : #locking }

--- a/src/OmniBase/ODBFile.class.st
+++ b/src/OmniBase/ODBFile.class.st
@@ -204,7 +204,7 @@ ODBFile >> waitForLockAt: pos length: length whileWaitingDo: aBlock [
 				ifFalse: [
 					ODBLockNotification signal
 						ifTrue: [startTime := currentTime]
-						ifFalse: [^ODBCannotLock signal]]]]
+						ifFalse: [ ^ ODBCannotLock signal ] ] ] ]
 ]
 
 { #category : #private }

--- a/src/OmniBase/ODBFileStream.class.st
+++ b/src/OmniBase/ODBFileStream.class.st
@@ -179,9 +179,9 @@ ODBFileStream class >> remove: fileName [
 	"Remove file named fileName. Answer <true> if successful, <false> if failed."
 
 	[ fileName asFileReference delete.
-		^true ]
+		^ true ]
 			on: Error
-			do: [:ex | ^false ]
+			do: [:ex | ^ false ]
 ]
 
 { #category : #'create/open flags' }

--- a/src/OmniBase/ODBGarbageCollector.class.st
+++ b/src/OmniBase/ODBGarbageCollector.class.st
@@ -256,12 +256,12 @@ ODBGarbageCollector >> runOn: anOmniBase silentMode: silenceBool [
 	"Run garbage collection on anOmniBase."
 
 	objectManager := anOmniBase objectManager.
-	[gcFile := ODBGarbageCollectorFile openOn: self gcFileName] on: Error
-		do: 
-			[:ex | 
+	[ gcFile := ODBGarbageCollectorFile openOn: self gcFileName ] 
+		on: Error
+		do: [:ex | 
 			objectManager isLocked ifTrue: [OmniBase signalError: 'Object manager is locked !'].
-			gcFile := ODBGarbageCollectorFile createOn: self gcFileName].
-	^self run: silenceBool
+			gcFile := ODBGarbageCollectorFile createOn: self gcFileName ].
+	^ self run: silenceBool
 ]
 
 { #category : #private }
@@ -297,8 +297,7 @@ ODBGarbageCollector >> walkObjectReferencesOf: objectID addInto: firstToDo oidSe
 	progressBlock value.
 	(objectManager holderAt: objectID)
 		ifNil: [ OmniBase signalError: 'Invalid object ID' ]
-		ifNotNil: [ :holder |
-			| dbObject |
+		ifNotNil: [ :holder | | dbObject |
 			dbObject := holder getObject.
 			dbObject referencesDo: [ :oid |
 				| containerID |
@@ -318,7 +317,7 @@ ODBGarbageCollector >> walkObjects [
 	"Private - Object traversal."
 
 	| toDo firstToDo oidSets set totalObjects count progressBlock |
-	gcFile status = 6 ifTrue: [ ^self ].
+	gcFile status = 6 ifTrue: [ ^ self ].
 	"create OID sets"
 	oidSets := OrderedCollection new.
 	"notifying progress count"


### PR DESCRIPTION
object space data file switch and lock waiting was not appropriate. Untangled loops and dependencies to switch a data file once and be able to unlock the same file that has been locked