### PR TITLE
ODBStream: push up stream var

### DIFF
--- a/src/OmniBase/ODBFileStream.class.st
+++ b/src/OmniBase/ODBFileStream.class.st
@@ -2,7 +2,6 @@ Class {
 	#name : #ODBFileStream,
 	#superclass : #ODBStream,
 	#instVars : [
-		'fileHandle',
 		'mutex',
 		'pathName'
 	],
@@ -280,25 +279,25 @@ ODBFileStream >> basicGetBytesFor: aByteCollection len: len [
 		"Read len bytes from stream to aByteCollection. 
 		Answer number of bytes actualy read."
 
-	^fileHandle flush; readInto: aByteCollection startingAt: 1 count: len
+	^stream flush; readInto: aByteCollection startingAt: 1 count: len
 ]
 
 { #category : #public }
 ODBFileStream >> basicPosition: anInteger [
 	"Positiones stream to anInteger. Answer anInteger."
 
-	fileHandle position: anInteger.
+	stream position: anInteger.
 	^anInteger
 ]
 
 { #category : #public }
 ODBFileStream >> basicPutBytesFrom: aByteArray len: length [ 
-	(fileHandle
+	(stream
 		writeFrom: aByteArray
 		startingAt: 1
 		for: length)
 		= length ifFalse: [OmniBase signalError: 'Could not write the whole data'].
-	fileHandle flush.
+	stream flush.
 	^self
 
 ]
@@ -334,7 +333,7 @@ ODBFileStream >> flush [
 		"Force all data written to the 
 		receiver to be recorded on disk."
 
-	fileHandle flush
+	stream flush
 ]
 
 { #category : #public }
@@ -400,7 +399,7 @@ ODBFileStream >> openOn: aString fileHandle: anIOAccessor [
 		"Private - Initialize receiver."
 
 	pathName := aString.
-	fileHandle := anIOAccessor.
+	stream := anIOAccessor.
 	mutex := Semaphore forMutualExclusion.
 ]
 
@@ -408,12 +407,6 @@ ODBFileStream >> openOn: aString fileHandle: anIOAccessor [
 ODBFileStream >> pathName [
 
     ^pathName
-]
-
-{ #category : #public }
-ODBFileStream >> position [
-
-	^fileHandle position
 ]
 
 { #category : #public }
@@ -468,21 +461,13 @@ ODBFileStream >> remove [
 ]
 
 { #category : #public }
-ODBFileStream >> size [
-	"Answer the size of the file in bytes or
-	signal a FileException if the operation fails."
-
-	^ fileHandle size
-]
-
-{ #category : #public }
 ODBFileStream >> truncate: anInteger [ 
 	"Truncate stream so that its size will be anInteger. 
         Position to anInteger."
 
 	mutex critical: 
 			[self basicPosition: anInteger.
-			fileHandle truncate: anInteger]
+			stream truncate: anInteger]
 ]
 
 { #category : #public }

--- a/src/OmniBase/ODBMacFileStream.class.st
+++ b/src/OmniBase/ODBMacFileStream.class.st
@@ -81,20 +81,20 @@ ODBMacFileStream class >> streamCreationSelectorForMode: createMode [
 ODBMacFileStream >> close [
 	"Close file associatied with receiver."
 
-	fileHandle notNil ifTrue: [
+	stream notNil ifTrue: [
 		BSDFLock 
-			unlock: fileHandle fileHandle 
+			unlock: stream fileHandle 
 			from: 0 
 			to: self size.
-		fileHandle closed ifFalse: [ fileHandle close ] ].
-	fileHandle := nil.
+		stream closed ifFalse: [ stream close ] ].
+	stream := nil.
 ]
 
 { #category : #public }
 ODBMacFileStream >> lockAt: pos length: length [
 	
 	^ BSDFLock 
-		lock: fileHandle fileHandle
+		lock: stream fileHandle
 		from: pos 
 		to: pos + length - 1
 ]
@@ -103,7 +103,7 @@ ODBMacFileStream >> lockAt: pos length: length [
 ODBMacFileStream >> unlockAt: pos length: length [
 
 	^ BSDFLock 
-		unlock: fileHandle fileHandle
+		unlock: stream fileHandle
 		from: pos 
 		to: pos + length - 1
 ]

--- a/src/OmniBase/ODBMemoryReadStream.class.st
+++ b/src/OmniBase/ODBMemoryReadStream.class.st
@@ -4,9 +4,6 @@ ODBMemoryReadStream wraps a ReadStream and provides easy data reading (e.g. getB
 Class {
 	#name : #ODBMemoryReadStream,
 	#superclass : #ODBStream,
-	#instVars : [
-		'stream'
-	],
 	#category : #'OmniBase-Streams'
 }
 
@@ -44,22 +41,7 @@ ODBMemoryReadStream >> getBytesFor: aByteCollection len: len [
 	^ stream readInto: aByteCollection startingAt: 1 count: len
 ]
 
-{ #category : #accessing }
-ODBMemoryReadStream >> position [
-	^ stream position
-]
-
-{ #category : #accessing }
-ODBMemoryReadStream >> position: aPostion [
-	stream position: aPostion
-]
-
 { #category : #'instance creation' }
 ODBMemoryReadStream >> readFrom: aStream [
 	stream := aStream
-]
-
-{ #category : #accessing }
-ODBMemoryReadStream >> size [
-	^ stream size
 ]

--- a/src/OmniBase/ODBMemoryWriteStream.class.st
+++ b/src/OmniBase/ODBMemoryWriteStream.class.st
@@ -4,9 +4,6 @@ ODBMemoryWriteStream wraps a WriteStream and provides easy data reading (e.g. ge
 Class {
 	#name : #ODBMemoryWriteStream,
 	#superclass : #ODBStream,
-	#instVars : [
-		'stream'
-	],
 	#category : #'OmniBase-Streams'
 }
 
@@ -20,16 +17,6 @@ ODBMemoryWriteStream >> initialize [
 	stream := WriteStream on: ByteArray new
 ]
 
-{ #category : #accessing }
-ODBMemoryWriteStream >> position [
-	^ stream position
-]
-
-{ #category : #accessing }
-ODBMemoryWriteStream >> position: aPostion [
-	stream position: aPostion
-]
-
 { #category : #public }
 ODBMemoryWriteStream >> putByte: anInteger [
 
@@ -39,11 +26,6 @@ ODBMemoryWriteStream >> putByte: anInteger [
 { #category : #public }
 ODBMemoryWriteStream >> putBytesFrom: aByteCollection len: len [
 	stream next: len putAll: aByteCollection startingAt: 1
-]
-
-{ #category : #accessing }
-ODBMemoryWriteStream >> size [
-	^ stream size
 ]
 
 { #category : #converting }

--- a/src/OmniBase/ODBStream.class.st
+++ b/src/OmniBase/ODBStream.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #ODBStream,
 	#superclass : #Object,
+	#instVars : [
+		'stream'
+	],
 	#classInstVars : [
 		'locks',
 		'lockingMutex'
@@ -81,12 +84,12 @@ ODBStream >> getWord [
 
 { #category : #accessing }
 ODBStream >> position [
-	^ self subclassResponsibility
+	^ stream position
 ]
 
 { #category : #accessing }
-ODBStream >> position: arg1 [ 
-	^ self subclassResponsibility
+ODBStream >> position: aPostion [
+	stream position: aPostion
 ]
 
 { #category : #public }
@@ -145,4 +148,9 @@ ODBStream >> setToEnd [
         "Set to stream to end and answer position."
 
     ^self position: self size
+]
+
+{ #category : #public }
+ODBStream >> size [
+	^ stream size
 ]

--- a/src/OmniBase/ODBUnixFileStream.class.st
+++ b/src/OmniBase/ODBUnixFileStream.class.st
@@ -91,20 +91,20 @@ ODBUnixFileStream class >> streamCreationSelectorForMode: createMode [
 ODBUnixFileStream >> close [
 	"Close file associatied with receiver."
 
-	fileHandle notNil ifTrue: [
+	stream notNil ifTrue: [
 		FLock 
-			unlock: fileHandle fileHandle 
+			unlock: stream fileHandle 
 			from: 0 
 			to: self size.
-		fileHandle closed ifFalse: [ fileHandle close ] ].
-	fileHandle := nil.
+		stream closed ifFalse: [ stream close ] ].
+	stream := nil.
 ]
 
 { #category : #public }
 ODBUnixFileStream >> lockAt: pos length: length [
 	
 	^ FLock 
-		lock: fileHandle fileHandle
+		lock: stream fileHandle
 		from: pos 
 		to: pos + length - 1
 ]
@@ -113,7 +113,7 @@ ODBUnixFileStream >> lockAt: pos length: length [
 ODBUnixFileStream >> unlockAt: pos length: length [
 
 	^ FLock 
-		unlock: fileHandle fileHandle
+		unlock: stream fileHandle
 		from: pos 
 		to: pos + length -1
 ]

--- a/src/OmniBase/ODBWin32FileStream.class.st
+++ b/src/OmniBase/ODBWin32FileStream.class.st
@@ -41,7 +41,7 @@ ODBWin32FileStream >> basicGetBytesFor: aByteCollection len: len [
 
 	| startTime currentTime errorCode |
 	(self 
-		readFile: fileHandle
+		readFile: stream
 		lpBuffer: aByteCollection
 		nNumberOfBytesToRead: len
 		lpNumberOfBytesRead: externalLong
@@ -58,7 +58,7 @@ ODBWin32FileStream >> basicGetBytesFor: aByteCollection len: len [
 										ifTrue: [startTime := currentTime]
 										ifFalse: [self fileIOError: errorCode]].
 							(self 
-								readFile: fileHandle
+								readFile: stream
 								lpBuffer: aByteCollection
 								nNumberOfBytesToRead: len
 								lpNumberOfBytesRead: externalLong
@@ -75,7 +75,7 @@ ODBWin32FileStream >> basicPosition: anInteger [
 
 	| result |
 	result := self 
-				setFilePointer: fileHandle
+				setFilePointer: stream
 				lDistanceToMove: anInteger
 				lpDistanceToMoveHigh: nil
 				dwMoveMethod: 0. "FILE_BEGIN"
@@ -87,7 +87,7 @@ ODBWin32FileStream >> basicPutBytesFrom: aByteCollection len: len [
 	"Private - Write len bytes from aByteCollection to file."
 
 	(self 
-		writeFile: fileHandle
+		writeFile: stream
 		lpBuffer: aByteCollection asByteArray
 		nNumberOfBytesToWrite: len
 		lpNumberOfBytesWritten: externalLong
@@ -98,8 +98,8 @@ ODBWin32FileStream >> basicPutBytesFrom: aByteCollection len: len [
 ODBWin32FileStream >> close [
 	"Close file associatied with receiver."
 
-	self closeHandle: fileHandle.
-	fileHandle := nil.
+	self closeHandle: stream.
+	stream := nil.
 ]
 
 { #category : #'Win32 primitives' }
@@ -190,7 +190,7 @@ ODBWin32FileStream >> fileIOError: errorCode [
 ODBWin32FileStream >> flush [
 	"Force all data written to the receiver to be recorded on disk."
 
-	(self flushFileBuffers: fileHandle) = 0 ifTrue: [self fileIOError]
+	(self flushFileBuffers: stream) = 0 ifTrue: [self fileIOError]
 ]
 
 { #category : #'Win32 primitives' }
@@ -236,7 +236,7 @@ ODBWin32FileStream >> lockAt: pos length: length [
 
 	| errorCode |
 	(self 
-		lockFile: fileHandle
+		lockFile: stream
 		offsetLow: pos
 		offsetHigh: 0
 		lengthLow: length
@@ -268,7 +268,8 @@ ODBWin32FileStream >> openOn: aString fileHandle: win32Handle [
 	"Private - Initialize receiver."
 
 	pathName := aString.
-	fileHandle := win32Handle.
+	"To fix: on win stream is a handle"
+	stream := win32Handle.
 	mutex := Semaphore forMutualExclusion.
 	externalLong := ByteArray new: 4.
 ]
@@ -277,7 +278,7 @@ ODBWin32FileStream >> openOn: aString fileHandle: win32Handle [
 ODBWin32FileStream >> position [
 	| pos |
 	pos := self 
-				setFilePointer: fileHandle
+				setFilePointer: stream
 				lDistanceToMove: 0
 				lpDistanceToMoveHigh: nil
 				dwMoveMethod: 1. "FILE_CURRENT"
@@ -340,7 +341,7 @@ ODBWin32FileStream >> size [
 	signal a FileException if the operation fails."
 
 	| result |
-	result := self getFileSize: fileHandle lpFileSizeHigh: nil.
+	result := self getFileSize: stream lpFileSizeHigh: nil.
 	^16rFFFFFFFF = result ifFalse: [result] ifTrue: [self fileIOError]
 ]
 
@@ -351,7 +352,7 @@ ODBWin32FileStream >> truncate: anInteger [
 
 	mutex critical: 
 			[self basicPosition: anInteger.
-			(self setEndOfFile: fileHandle) = 0 ifTrue: [self fileIOError]]
+			(self setEndOfFile: stream) = 0 ifTrue: [self fileIOError]]
 ]
 
 { #category : #public }
@@ -360,7 +361,7 @@ ODBWin32FileStream >> unlockAt: pos length: length [
 	Answer <true> if successfull, <false> if failed."
 
 	^(self
-		unlockFile: fileHandle
+		unlockFile: stream
 		offsetLow: pos
 		offsetHigh: 0
 		lengthLow: length


### PR DESCRIPTION
- move ivar stream to ODBStream
- use it instead of fileHandle
- cleanup not-needed methods

The only not-that-nice aspect is that in ODBWin32FileStream, stream is now used for a filehandle.

fixes  #61