### PR TITLE
 isNil-cleanup-ODBChange

### DIFF
--- a/src/OmniBase/ODBAssociationChanged.class.st
+++ b/src/OmniBase/ODBAssociationChanged.class.st
@@ -17,7 +17,7 @@ ODBAssociationChanged class >> changeClassID [
     ^2
 ]
 
-{ #category : #'public/transaction processing' }
+{ #category : #'transaction processing' }
 ODBAssociationChanged >> commit [
 
     transactionObject dataBaseObject at: key put: newValue
@@ -29,7 +29,7 @@ ODBAssociationChanged >> key: aString [
     key := aString
 ]
 
-{ #category : #'public/load/store' }
+{ #category : #public }
 ODBAssociationChanged >> loadFromStream: aStream [
 
     objectID := ODBObjectID new loadFromStream: aStream.
@@ -50,13 +50,13 @@ ODBAssociationChanged >> oldValue: aValue [
     oldValue := aValue
 ]
 
-{ #category : #'public/transaction processing' }
+{ #category : #'transaction processing' }
 ODBAssociationChanged >> rollback [
 
     self transactionObject dataBaseObject at: key put: oldValue
 ]
 
-{ #category : #'public/load/store' }
+{ #category : #'load/store' }
 ODBAssociationChanged >> storeOnStream: aStream [
 
     objectID storeOnStream: aStream.

--- a/src/OmniBase/ODBChange.class.st
+++ b/src/OmniBase/ODBChange.class.st
@@ -64,9 +64,8 @@ ODBChange >> transaction: aTransaction [
 
 { #category : #public }
 ODBChange >> transactionObject [
-	^transactionObject isNil 
-		ifFalse: [transactionObject]
-		ifTrue: [transactionObject := transaction transactionObjectAt: objectID]
+
+	^ transactionObject ifNil: [ transactionObject := transaction transactionObjectAt: objectID ]
 ]
 
 { #category : #accessing }

--- a/src/OmniBase/ODBChangesPackage.class.st
+++ b/src/OmniBase/ODBChangesPackage.class.st
@@ -21,8 +21,7 @@ ODBChangesPackage >> changes [
 ODBChangesPackage >> collectChangeClassIDsFrom: rootClass to: aDictionary [
         "Private - Collect all change classIDs and store them to aDictionary."
 
-    rootClass changeClassID notNil
-        ifTrue: [aDictionary at: rootClass changeClassID put: rootClass].
+    rootClass changeClassID ifNotNil: [aDictionary at: rootClass changeClassID put: rootClass].
     rootClass subclasses do: [:each | self collectChangeClassIDsFrom: each to: aDictionary]
 ]
 
@@ -33,7 +32,7 @@ ODBChangesPackage >> commit [
 
 { #category : #'public/unclassified' }
 ODBChangesPackage >> committed [
-        "Changes have just been committed."
+    "Changes have just been committed."
 
     changes do: [:each | each committed]
 ]
@@ -70,17 +69,16 @@ ODBChangesPackage >> rollback [
 ]
 
 { #category : #public }
-ODBChangesPackage >> storeOnStream: aStream [ 
+ODBChangesPackage >> storeOnStream: aStream [
+
 	"Store receiver on aStream."
 
 	| memoryStream classID |
 	memoryStream := ODBMemoryWriteStream new.
-	changes do: 
-			[:each | 
-			(classID := each class changeClassID) isNil 
-				ifFalse: 
-					[memoryStream putByte: classID.
-					each storeOnStream: memoryStream]].
+	changes do: [ :each | 
+		(classID := each class changeClassID) ifNotNil: [ 
+			memoryStream putByte: classID.
+			each storeOnStream: memoryStream ] ].
 	memoryStream
 		putByte: 0;
 		writeOn: aStream
@@ -92,14 +90,15 @@ ODBChangesPackage >> transaction: aTransaction [
 ]
 
 { #category : #private }
-ODBChangesPackage >> value: change1 value: change2 [ 
+ODBChangesPackage >> value: change1 value: change2 [
+
 	"Private - Answer <true> if change1 is to be committed before change2.
 	Disk access optimization so that files are updated sequentialy."
 
 	| oid1 oid2 cid1 cid2 |
-	(oid1 := change1 objectID) isNil ifTrue: [^true].
-	(oid2 := change2 objectID) isNil ifTrue: [^false].
-	(cid1 := oid1 containerID) == (cid2 := oid2 containerID) 
-		ifTrue: [^oid1 index < oid2 index].
-	^cid1 < cid2
+	(oid1 := change1 objectID) ifNil: [ ^ true ].
+	(oid2 := change2 objectID) ifNil: [ ^ false ].
+	(cid1 := oid1 containerID) == (cid2 := oid2 containerID) ifTrue: [ 
+		^ oid1 index < oid2 index ].
+	^ cid1 < cid2
 ]

--- a/src/OmniBase/ODBContainer.class.st
+++ b/src/OmniBase/ODBContainer.class.st
@@ -25,30 +25,34 @@ ODBContainer >> addByteStorageRequest: anODBByteStorageRequest [
 	queueSize > 65536 ifTrue: [self flushBytes]
 ]
 
-{ #category : #public }
-ODBContainer >> at: index [ 
+{ #category : #accessing }
+ODBContainer >> at: index [
+
 	| bytes |
-	(bytes := indexFile at: index) isNil ifTrue: [^nil].
-	^(ODBObjectHolder createOn: bytes) setContainer: self
-		objectID: (ODBObjectID containerID: id index: index)
+	(bytes := indexFile at: index) ifNil: [ ^ nil ].
+	^ (ODBObjectHolder createOn: bytes)
+		  setContainer: self
+		  objectID: (ODBObjectID containerID: id index: index)
 ]
 
 { #category : #accessing }
 ODBContainer >> bytesAllocated [
+
 	| size1 size2 |
 	size1 := 0.
 	size2 := 0.
-	dataFileA isNil ifFalse: [size1 := dataFileA size].
-	dataFileB isNil ifFalse: [size2 := dataFileB size].
-	^size1 + size2
+	dataFileA ifNotNil: [ size1 := dataFileA size ].
+	dataFileB ifNotNil: [ size2 := dataFileB size ].
+	^ size1 + size2
 ]
 
 { #category : #public }
 ODBContainer >> close [
-	dbFiles do: [:each | each isNil ifFalse: [each close]].
-	indexFile isNil ifFalse: [indexFile close].
-	dataFileA isNil ifFalse: [dataFileA close].
-	dataFileB isNil ifFalse: [dataFileB close]
+
+	dbFiles do: [ :each | each ifNotNil: [ each close ] ].
+	indexFile ifNotNil: [ indexFile close ].
+	dataFileA ifNotNil: [ dataFileA close ].
+	dataFileB ifNotNil: [ dataFileB close ]
 ]
 
 { #category : #public }
@@ -71,12 +75,14 @@ ODBContainer >> convertToLocalObjectSpaceNumber: objectSpaceNumber [
 
 { #category : #public }
 ODBContainer >> createNewObjectSpace [
+
 	"Create new object space for garbage collection."
 
-	dataFileA isNil 
-		ifTrue: [dataFileA := ODBObjectStorage createOn: self dataFileNameA]
-		ifFalse: 
-			[dataFileB isNil ifTrue: [dataFileB := ODBObjectStorage createOn: self dataFileNameB]]
+	dataFileA
+		ifNil: [ dataFileA := ODBObjectStorage createOn: self dataFileNameA ]
+		ifNotNil: [ 
+			dataFileB ifNil: [ 
+				dataFileB := ODBObjectStorage createOn: self dataFileNameB ] ]
 ]
 
 { #category : #public }
@@ -113,10 +119,10 @@ ODBContainer >> dataFileSize [
 
 { #category : #'private-accessing' }
 ODBContainer >> dirName [
-        "Private - Needed by database objects that 
-        are creating their own files."
 
-    ^path
+	"Private - Needed by database objects that are creating their own files."
+
+	^ path
 ]
 
 { #category : #private }

--- a/src/OmniBase/ODBDictionaryChanged.class.st
+++ b/src/OmniBase/ODBDictionaryChanged.class.st
@@ -7,11 +7,12 @@ Class {
 	#category : #'OmniBase-Events'
 }
 
-{ #category : #public }
+{ #category : #'transaction processing' }
 ODBDictionaryChanged >> committed [
+
 	"Changes have been committed, update transaction object."
 
-	dataBaseObject isNil ifFalse: [transactionObject setDataBaseObject: dataBaseObject].
+	dataBaseObject ifNotNil: [ transactionObject setDataBaseObject: dataBaseObject ].
 	transactionObject objectCommitted
 ]
 

--- a/src/OmniBase/ODBGarbageCollectorRequest.class.st
+++ b/src/OmniBase/ODBGarbageCollectorRequest.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'OmniBase-Storage'
 }
 
-{ #category : #public }
+{ #category : #'public/unclassified' }
 ODBGarbageCollectorRequest >> bytesStored [
 	objectHolder container indexFile at: objectHolder objectID index
 		put: objectHolder contents

--- a/src/OmniBase/ODBNewObjectVersion.class.st
+++ b/src/OmniBase/ODBNewObjectVersion.class.st
@@ -16,14 +16,14 @@ ODBNewObjectVersion class >> changeClassID [
     ^1
 ]
 
-{ #category : #'public/transaction processing' }
+{ #category : #'transaction processing' }
 ODBNewObjectVersion >> commit [
         "Commit changes."
 
     newVersion store
 ]
 
-{ #category : #'public/transaction processing' }
+{ #category : #'transaction processing' }
 ODBNewObjectVersion >> committed [
         "Changes have been committed, update transaction object."
 
@@ -32,7 +32,7 @@ ODBNewObjectVersion >> committed [
         objectCommitted
 ]
 
-{ #category : #'public/load/store' }
+{ #category : #public }
 ODBNewObjectVersion >> loadFromStream: aStream [
 
     objectID := ODBObjectID new loadFromStream: aStream.
@@ -64,23 +64,23 @@ ODBNewObjectVersion >> oldVersion: anObjectHolder [
     oldVersion := anObjectHolder
 ]
 
-{ #category : #public }
+{ #category : #'transaction processing' }
 ODBNewObjectVersion >> rollback [
+
 	"Rollback changes."
 
 	| currentHolder |
-	(currentHolder := transaction objectHolderAt: objectID) isNil ifTrue: [^self].
-	currentHolder versionNumber > newVersion versionNumber 
-		ifFalse: 
-			[currentHolder
-				contents: oldVersion contents;
-				store]
+	(currentHolder := transaction objectHolderAt: objectID) ifNil: [ ^ self ].
+	currentHolder versionNumber > newVersion versionNumber ifFalse: [ 
+		currentHolder
+			contents: oldVersion contents;
+			store ]
 ]
 
-{ #category : #'public/load/store' }
+{ #category : #'load/store' }
 ODBNewObjectVersion >> storeOnStream: aStream [
 
-        objectID storeOnStream: aStream.
-        oldVersion storeOnStream: aStream.
-        newVersion storeOnStream: aStream
+	objectID storeOnStream: aStream.
+	oldVersion storeOnStream: aStream.
+	newVersion storeOnStream: aStream
 ]

--- a/src/OmniBase/ODBSizeChanged.class.st
+++ b/src/OmniBase/ODBSizeChanged.class.st
@@ -15,7 +15,7 @@ ODBSizeChanged class >> changeClassID [
     ^4
 ]
 
-{ #category : #'public/transaction processing' }
+{ #category : #'transaction processing' }
 ODBSizeChanged >> commit [
 
     transaction := transactionObject transaction.
@@ -25,20 +25,20 @@ ODBSizeChanged >> commit [
         deltaSize: deltaSize
 ]
 
-{ #category : #'public/accessing' }
+{ #category : #accessing }
 ODBSizeChanged >> deltaSize: anInteger [
 
     deltaSize := anInteger
 ]
 
-{ #category : #'public/load/store' }
+{ #category : #public }
 ODBSizeChanged >> loadFromStream: aStream [
 
     objectID := ODBObjectID new loadFromStream: aStream.
     deltaSize := aStream getInteger
 ]
 
-{ #category : #'public/transaction processing' }
+{ #category : #'transaction processing' }
 ODBSizeChanged >> rollback [
 
     self transactionObject dataBaseObject iterator
@@ -47,7 +47,7 @@ ODBSizeChanged >> rollback [
         deltaSize: 0 - deltaSize
 ]
 
-{ #category : #'public/load/store' }
+{ #category : #'load/store' }
 ODBSizeChanged >> storeOnStream: aStream [
 
     objectID storeOnStream: aStream.

--- a/src/OmniBase/ODBValueHolder.class.st
+++ b/src/OmniBase/ODBValueHolder.class.st
@@ -29,11 +29,10 @@ ODBValueHolder >> getObjectIn: aTransaction [
 
 { #category : #public }
 ODBValueHolder >> isRemoved [
-	"Answer <true> if the key has been removed 
-	(there is no value associated with it)."
 
-	removed isNil ifFalse: [^removed].
-	^removed := (self uLongAtOffset: 8) = 0
+	"Answer <true> if the key has been removed (there is no value associated with it)."
+
+	^ removed ifNil: [ removed := (self uLongAtOffset: 8) = 0 ]
 ]
 
 { #category : #public }

--- a/src/OmniBase/OmniBase.class.st
+++ b/src/OmniBase/OmniBase.class.st
@@ -264,8 +264,7 @@ OmniBase >> classManagerClass [
 { #category : #private }
 OmniBase >> clientManager [
 
-	^ clientManager ifNil: [ 
-		clientManager := self clientManagerClass new ]
+	^ clientManager ifNil: [ clientManager := self clientManagerClass new ]
 ]
 
 { #category : #public }


### PR DESCRIPTION
This PR does a small critique rule-driven cleanup of the RBChange hierarchy

- categorize subclasses the same as the superclass
- do not use #isNil