### PR TITLE
Cleanup-unused-lockingMutex

### DIFF
--- a/src/OmniBase/ODBFileStream.class.st
+++ b/src/OmniBase/ODBFileStream.class.st
@@ -122,16 +122,6 @@ ODBFileStream class >> exists: fileName [
 	^ fileName asFileReference exists
 ]
 
-{ #category : #locking }
-ODBFileStream class >> lockingMutex [
-
-	lockingMutex isNil
-		ifTrue: [
-			lockingMutex := Semaphore forMutualExclusion.
-			locks := Dictionary new ].
-	^lockingMutex
-]
-
 { #category : #'create/open' }
 ODBFileStream class >> openExclusivelyOn: pathName [
 		"Open an existing file on pathName exclusively so that no-one else can open it.

--- a/src/OmniBase/ODBStream.class.st
+++ b/src/OmniBase/ODBStream.class.st
@@ -4,10 +4,6 @@ Class {
 	#instVars : [
 		'stream'
 	],
-	#classInstVars : [
-		'locks',
-		'lockingMutex'
-	],
 	#category : #'OmniBase-Streams'
 }
 


### PR DESCRIPTION


ODBFileStream class>>lockingMutex is never called, the variable it access never accessed outside of the method