### PR TITLE
23-Serializer-ByteArrays-are-not-stored-using-ODBByteArrayCode 

### DIFF
--- a/src/OmniBase-Tests/ODBSerializationTest.class.st
+++ b/src/OmniBase-Tests/ODBSerializationTest.class.st
@@ -74,9 +74,8 @@ ODBSerializationTest >> testSerializationByteArray [
 	| object serialized materialized |
 	object := #[1 2 3 5].
 	serialized := ODBSerializer serializeToBytes: object.
-	self assert: serialized equals: #[0 1 9 66 121 116 101 65 114 114 97 121 1 1 0 1 0 0 0 2 1 4 1 2 3 5].
-	"self assert: (serialized at: 7) equals: ODBByteArrayCode."
-	self flag: #TODO. "Implement ByteArray Serialisation and de-serialization"
+	self assert: serialized equals: #[0 0 1 0 0 0 80 4 1 2 3 5].
+	self assert: (serialized at: 7) equals: ODBByteArrayCode.
 
 	materialized := ODBDeserializer deserializeFromBytes: serialized.
 	self assert: materialized equals: object

--- a/src/OmniBase/ByteArray.extension.st
+++ b/src/OmniBase/ByteArray.extension.st
@@ -27,6 +27,23 @@ ByteArray >> odbAsInteger [
 	^result
 ]
 
+{ #category : #'*OmniBase' }
+ByteArray >> odbBasicSerialize: serializer [
+
+	serializer stream putByte: 80; putPositiveInteger: self size.
+	1 to: self size do: [:i |serializer stream putByte: (self at: i)].
+]
+
+{ #category : #'*OmniBase' }
+ByteArray class >> odbDeserialize: deserializer [
+
+	| array |
+	array := self new: deserializer stream getPositiveInteger.
+	deserializer register: array.
+	1 to: array size do: [:i | array at: i put: deserializer stream getPositiveInteger ].
+	^array
+]
+
 { #category : #'*omnibase' }
 ByteArray >> odbIsLessOrEqualTo: aByteArray [
 


### PR DESCRIPTION
This PR implements special serialization and deserialization for ByteArrays. This should save some space when storing them.

fixes #23

This is backward compatible, old serialized ByteArrays are stored as standard objects and will deserialize as such.