### PR TITLE
 17-ODBBTreeIndexDictionaryisEmpty-is-broken 

### DIFF
--- a/src/OmniBase-Tests/ODBBTreeIndexDictionaryTest.class.st
+++ b/src/OmniBase-Tests/ODBBTreeIndexDictionaryTest.class.st
@@ -61,6 +61,15 @@ ODBBTreeIndexDictionaryTest >> testIsChanged [
 ]
 
 { #category : #tests }
+ODBBTreeIndexDictionaryTest >> testIsEmpty [
+	[ | dict |
+	dict := OmniBase newBTreeIndexDictionary: 10.
+	self assert: dict isEmpty.
+	dict at: #test put: true.
+	self deny: dict isEmpty ] evaluateAndCommitIn: db newTransaction
+]
+
+{ #category : #tests }
 ODBBTreeIndexDictionaryTest >> testKeyLength [
  	| dict |
  	[ dict := (OmniBase newBTreeIndexDictionary: 10)
@@ -115,6 +124,15 @@ ODBBTreeIndexDictionaryTest >> testRemoveKey [
 	 ] evaluateAndCommitIn: db newTransaction.
 	self assert: (dict at: #test).
 	self assert: dict values size equals: 1
+]
+
+{ #category : #tests }
+ODBBTreeIndexDictionaryTest >> testSize [
+	[ | dict |
+	dict := OmniBase newBTreeIndexDictionary: 10.
+	self assert: dict isEmpty.
+	dict at: #test put: true.
+	self assert: dict size equals: 1 ] evaluateAndCommitIn: db newTransaction
 ]
 
 { #category : #tests }

--- a/src/OmniBase/ODBBTreeDictionary.class.st
+++ b/src/OmniBase/ODBBTreeDictionary.class.st
@@ -163,6 +163,11 @@ ODBBTreeDictionary >> initialize [
 ]
 
 { #category : #public }
+ODBBTreeDictionary >> isEmpty [
+	^self size = 0
+]
+
+{ #category : #public }
 ODBBTreeDictionary >> isKeyLocked: aKey [ 
 	"Answer <true> if aKey is locked."
 

--- a/src/OmniBase/ODBBTreeIndexDictionary.class.st
+++ b/src/OmniBase/ODBBTreeIndexDictionary.class.st
@@ -374,7 +374,7 @@ ODBBTreeIndexDictionary >> isChanged [
 
 { #category : #public }
 ODBBTreeIndexDictionary >> isEmpty [
-	^self size = 0
+	^self getFirst isNil
 ]
 
 { #category : #private }
@@ -529,6 +529,14 @@ ODBBTreeIndexDictionary >> selectKeysStartingWith: aString [
 		to: toKey
 		do: [:key | keys add: key].
 	^keys
+]
+
+{ #category : #accessing }
+ODBBTreeIndexDictionary >> size [
+	"NOTE: Better do not use this!
+	All objects will be loaded in one transaction at once.
+	Do not use this method if there are a lot of objects in the dictionary since this could block your image for some time."
+	^self values size
 ]
 
 { #category : #public }


### PR DESCRIPTION
- Implement isEmpty and size for ODBBTreeIndexDictionary
- copy down the old implementation to ODBBTreeDictionary (which has the concept of size)
- add tests for size and #isEmpty

fixes #17