### PR TITLE
Pharo10-testSerializationIdentityDictionary

### DIFF
--- a/src/OmniBase-Tests/ODBSerializationTest.class.st
+++ b/src/OmniBase-Tests/ODBSerializationTest.class.st
@@ -155,7 +155,10 @@ ODBSerializationTest >> testSerializationIdentityDictionary [
 	| object serialized materialized |
 	object := IdentityDictionary newFrom: { #test->2 . #now->4 }.
 	serialized := ODBSerializer serializeToBytes: object.
-	self assert: serialized equals: #[0 0 1 0 0 0 38 2 18 4 116 101 115 116 52 18 3 110 111 119 54].
+	self assert: (serialized = 
+	"the order of association in the dict is different between Pharo9 and Pharo10, no idea why"
+	#[0 0 1 0 0 0 38 2 18 3 110 111 119 54 18 4 116 101 115 116 52] or: [  
+	#[0 0 1 0 0 0 38 2 18 4 116 101 115 116 52 18 3 110 111 119 54]]).
 	self assert: (serialized at: 7) equals: ODBIdentityDictionaryCode.
 
 	materialized := ODBDeserializer deserializeFromBytes: serialized.


### PR DESCRIPTION
The order of associations in the internal array created by

```
IdentityDictionary newFrom: { #test->2 . #now->4 }. 
```

is different between Pharo10 and Pharo9.

This PR changes the assert to allow both