### PR TITLE
Trivial Clean: ODBPersistentDictionary

### DIFF
--- a/src/OmniBase/Class.extension.st
+++ b/src/OmniBase/Class.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #Class }
 { #category : #'*omnibase' }
 Class class >> odbDeserialize: deserializer [
 
-	^Smalltalk at: deserializer stream getString asSymbol ifAbsent: []
+	^Smalltalk at: deserializer stream getString asSymbol ifAbsent: nil
 ]
 
 { #category : #'*omnibase' }

--- a/src/OmniBase/ODBBTreeIndexDictionary.class.st
+++ b/src/OmniBase/ODBBTreeIndexDictionary.class.st
@@ -19,7 +19,7 @@ ODBBTreeIndexDictionary class >> createWithKeyLength: keyLength [
 { #category : #accessing }
 ODBBTreeIndexDictionary >> at: aKey [
 
-    ^self at: aKey ifAbsent: []
+    ^self at: aKey ifAbsent: nil
 ]
 
 { #category : #public }

--- a/src/OmniBase/ODBClassDescription.class.st
+++ b/src/OmniBase/ODBClassDescription.class.st
@@ -127,7 +127,7 @@ ODBClassDescription >> saveOnStream: aStream [
 { #category : #private }
 ODBClassDescription >> updateVariableOrder [
 	| realNames |
-	class := Smalltalk at: name asSymbol ifAbsent: [].
+	class := Smalltalk at: name asSymbol ifAbsent: nil.
 	varOrder := Array new: instVarNames size.
 	class isNil 
 		ifTrue: [varOrder atAllPut: 1]

--- a/src/OmniBase/ODBPersistentDictionary.class.st
+++ b/src/OmniBase/ODBPersistentDictionary.class.st
@@ -19,21 +19,23 @@ ODBPersistentDictionary class >> odbDeserialize: deserializer [
 	^dict
 ]
 
-{ #category : #public }
-ODBPersistentDictionary >> add: anAssociation [ 
+{ #category : #adding }
+ODBPersistentDictionary >> add: anAssociation [
+
 	| t |
 	t := transaction.
-	anAssociation key isODBReference ifTrue: [self error: 'Invalid key!'].
+	anAssociation key isODBReference ifTrue: [ 
+		self error: 'Invalid key!' ].
 	super add: anAssociation.
 	transaction := t.
-	transaction isNil ifTrue: [^anAssociation].
-	anAssociation value isImmediateObject 
-		ifFalse: [transaction makePersistent: anAssociation value].
+	transaction ifNil: [ ^ anAssociation ].
+	anAssociation value isImmediateObject ifFalse: [ 
+		transaction makePersistent: anAssociation value ].
 	transaction markDirty: self.
-	^anAssociation
+	^ anAssociation
 ]
 
-{ #category : #public }
+{ #category : #converting }
 ODBPersistentDictionary >> asDictionary [
 	| dict |
 	dict := Dictionary new.
@@ -41,19 +43,21 @@ ODBPersistentDictionary >> asDictionary [
 	^dict
 ]
 
-{ #category : #public }
-ODBPersistentDictionary >> at: key put: value [ 
+{ #category : #accessing }
+ODBPersistentDictionary >> at: key put: value [
+
 	| oldValue |
-	key isODBReference ifTrue: [self error: 'Invalid key!'].
-	oldValue := super at: key ifAbsent: [].
-	value == oldValue ifTrue: [^value].
+	key isODBReference ifTrue: [ self error: 'Invalid key!' ].
+	oldValue := self at: key ifAbsent: nil.
+	value == oldValue ifTrue: [ ^ value ].
 	oldValue := transaction.
 	super at: key put: value.
 	transaction := oldValue.
-	transaction isNil ifTrue: [^value].
+	transaction ifNil: [ ^ value ].
 	transaction markDirty: self.
-	(value isImmediateObject or: [value == key]) ifFalse: [transaction makePersistent: value].
-	^value
+	(value isImmediateObject or: [ value == key ]) ifFalse: [ 
+		transaction makePersistent: value ].
+	^ value
 ]
 
 { #category : #public }
@@ -69,7 +73,7 @@ ODBPersistentDictionary >> odbBasicSerialize: serializer [
 
 { #category : #private }
 ODBPersistentDictionary >> odbLoadedIn: anOmniBaseTransaction [
-		"This method is sent when the object is loaded from the database."
+	"This method is sent when the object is loaded from the database."
 
 	transaction := anOmniBaseTransaction
 ]
@@ -78,19 +82,19 @@ ODBPersistentDictionary >> odbLoadedIn: anOmniBaseTransaction [
 ODBPersistentDictionary >> odbMadePersistentIn: anOmniBaseTransaction [ 
 	"This method is sent when the object is made persistent."
 
-	transaction notNil 
-		ifTrue: [self error: 'Object is already persistent in another transaction'].
+	transaction ifNotNil: [self error: 'Object is already persistent in another transaction'].
 	transaction := anOmniBaseTransaction.
 	self do: [:each | each isImmediateObject ifFalse: [transaction makePersistent: each]]
 ]
 
-{ #category : #public }
-ODBPersistentDictionary >> removeKey: aKey ifAbsent: aBlock [ 
+{ #category : #removing }
+ODBPersistentDictionary >> removeKey: aKey ifAbsent: aBlock [
+
 	| t |
 	t := transaction.
-	super removeKey: aKey ifAbsent: [^aBlock value].
+	super removeKey: aKey ifAbsent: [ ^ aBlock value ].
 	transaction := t.
-	transaction isNil ifFalse: [transaction markDirty: self]
+	transaction ifNotNil: [ transaction markDirty: self ]
 ]
 
 { #category : #private }

--- a/src/OmniBase/OmniBase.class.st
+++ b/src/OmniBase/OmniBase.class.st
@@ -119,7 +119,7 @@ OmniBase class >> getCurrentAndSet: anOmniBaseTransaction for: aProcess [
 
 	| previousTxn |
 	processToTransactionMutex critical: 
-			[previousTxn := processToTransactionDict at: aProcess ifAbsent: [].
+			[previousTxn := processToTransactionDict at: aProcess ifAbsent: nil.
 			processToTransactionDict at: aProcess put: anOmniBaseTransaction].
 	^previousTxn
 ]


### PR DESCRIPTION
- Code critique clean of ODBPersistentDictionary (ifNil, categories)
- replace some [] with nil, as "nil value" is much faster than "[] value". (this is kind of a poor man's clean block... but it is even faster than the clean "[] value" will be)