### PR TITLE
 29-Refactoring-improve-odbSerialize-vs-odbBasicSerialize 

### DIFF
--- a/src/OmniBase/Character.extension.st
+++ b/src/OmniBase/Character.extension.st
@@ -19,9 +19,5 @@ Character class >> odbDeserialize: deserializer [
 { #category : #'*omnibase' }
 Character >> odbSerialize: serializer [
 
-	self asInteger < 256 ifTrue: [
-		serializer stream putByte: 13; putChar: self.
-		^self
-	].
-	serializer stream putByte: 29; putWord: self asInteger
+	self odbBasicSerialize: serializer
 ]

--- a/src/OmniBase/Class.extension.st
+++ b/src/OmniBase/Class.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : #Class }
 
 { #category : #'*omnibase' }
+Class >> odbBasicSerialize: serializer [
+
+	serializer stream putByte: 26; putString: name asString
+]
+
+{ #category : #'*omnibase' }
 Class class >> odbDeserialize: deserializer [
 
 	^Smalltalk at: deserializer stream getString asSymbol ifAbsent: nil
@@ -9,7 +15,7 @@ Class class >> odbDeserialize: deserializer [
 { #category : #'*omnibase' }
 Class >> odbSerialize: serializer [
 
-	serializer stream putByte: 26; putString: name asString
+	self odbBasicSerialize: serializer
 ]
 
 { #category : #'*omnibase' }

--- a/src/OmniBase/False.extension.st
+++ b/src/OmniBase/False.extension.st
@@ -15,5 +15,5 @@ False >> odbObjectID [
 { #category : #'*omnibase' }
 False >> odbSerialize: serializer [
 
-	serializer stream putByte: 16
+	self odbBasicSerialize: serializer
 ]

--- a/src/OmniBase/Fraction.extension.st
+++ b/src/OmniBase/Fraction.extension.st
@@ -19,8 +19,5 @@ Fraction class >> odbDeserialize: deserializer [
 { #category : #'*omnibase' }
 Fraction >> odbSerialize: serializer [
 
-	serializer stream
-		putByte: 39;
-		putInteger: numerator;
-		putInteger: denominator
+	self odbBasicSerialize: serializer
 ]

--- a/src/OmniBase/Integer.extension.st
+++ b/src/OmniBase/Integer.extension.st
@@ -38,10 +38,5 @@ Integer >> odbBasicSerialize: serializer [
 { #category : #'*omnibase' }
 Integer >> odbSerialize: serializer [
 
-	self < 0 ifTrue: [
-		self > -4 ifTrue: [ ^serializer stream putByte: self + 70 ].
-		^serializer stream putByte: 12; putPositiveInteger: 0 - self.
-	].
-	self < 17 ifTrue: [ ^serializer stream putByte: self + 50 ].
-	serializer stream putByte: 11; putPositiveInteger: self
+	self odbBasicSerialize: serializer
 ]

--- a/src/OmniBase/ODBTransaction.class.st
+++ b/src/OmniBase/ODBTransaction.class.st
@@ -274,7 +274,7 @@ ODBTransaction >> odbObjectID [
 { #category : #'private/unclassified' }
 ODBTransaction >> odbSerialize: serializer [
 
-	serializer stream putByte: 84
+	self odbBasicSerialize: serializer
 ]
 
 { #category : #'private/accessing' }

--- a/src/OmniBase/ProcessorScheduler.extension.st
+++ b/src/OmniBase/ProcessorScheduler.extension.st
@@ -9,5 +9,5 @@ ProcessorScheduler >> odbBasicSerialize: serializer [
 { #category : #'*omnibase' }
 ProcessorScheduler >> odbSerialize: serializer [
 
-	serializer stream putByte: 22
+	self odbBasicSerialize: serializer
 ]

--- a/src/OmniBase/SmallFloat64.extension.st
+++ b/src/OmniBase/SmallFloat64.extension.st
@@ -1,9 +1,14 @@
 Extension { #name : #SmallFloat64 }
 
 { #category : #'*OmniBase' }
-SmallFloat64 >> odbSerialize: serializer [ 
+SmallFloat64 >> odbBasicSerialize: serializer [ 
 	serializer stream
 		putByte: 47;
 		putInteger: (self at: 1);
 		putInteger: (self at: 2)  
+]
+
+{ #category : #'*OmniBase' }
+SmallFloat64 >> odbSerialize: serializer [ 
+	self odbBasicSerialize: serializer
 ]

--- a/src/OmniBase/Symbol.extension.st
+++ b/src/OmniBase/Symbol.extension.st
@@ -21,8 +21,5 @@ Symbol class >> odbDeserialize: deserializer [
 { #category : #'*omnibase' }
 Symbol >> odbSerialize: serializer [
 
-	serializer stream
-		putByte: 18;
-		putPositiveInteger: self size;
-		putBytesFrom: self asByteArray len: self size
+	self odbBasicSerialize: serializer
 ]

--- a/src/OmniBase/SystemDictionary.extension.st
+++ b/src/OmniBase/SystemDictionary.extension.st
@@ -9,5 +9,5 @@ SystemDictionary >> odbBasicSerialize: serializer [
 { #category : #'*omnibase' }
 SystemDictionary >> odbSerialize: serializer [
 
-	serializer stream putByte: 19
+	self odbBasicSerialize: serializer
 ]

--- a/src/OmniBase/True.extension.st
+++ b/src/OmniBase/True.extension.st
@@ -15,5 +15,5 @@ True >> odbObjectID [
 { #category : #'*omnibase' }
 True >> odbSerialize: serializer [
 
-	serializer stream putByte: 15
+	self odbBasicSerialize: serializer
 ]

--- a/src/OmniBase/UndefinedObject.extension.st
+++ b/src/OmniBase/UndefinedObject.extension.st
@@ -33,5 +33,5 @@ UndefinedObject >> odbObjectID [
 { #category : #'*omnibase' }
 UndefinedObject >> odbSerialize: serializer [
 
-	serializer stream putByte: 14
+	self odbBasicSerialize: serializer
 ]


### PR DESCRIPTION
make sure to implement serialization in #odbBasicSerialize:, override in #odbSerialize: for the cases we do not want to register the object

Code coverage analysis of the serialization methods now look much better

fixes #29

