### PR TITLE
26-Serializer-Problems-with-SystemDictionary-Smalltalk

### DIFF
--- a/src/OmniBase-Tests/ODBSerializationTest.class.st
+++ b/src/OmniBase-Tests/ODBSerializationTest.class.st
@@ -389,9 +389,7 @@ ODBSerializationTest >> testSerializationSystemDictionary [
 	self assert: (serialized at: 7) equals: ODBSystemDictionaryCode.
 
 	materialized := ODBDeserializer deserializeFromBytes: serialized.
-	self flag: #TODO.
-	"this shows that we do not de-serialize the dictionary, but the global Smalltalk binding"
-	self assert: materialized equals: Smalltalk
+	self assert: materialized equals: Smalltalk globals
 ]
 
 { #category : #tests }

--- a/src/OmniBase/ODBDeserializer.class.st
+++ b/src/OmniBase/ODBDeserializer.class.st
@@ -72,7 +72,7 @@ ODBDeserializer class >> init [
 		at: 16 put: false;
 		at: 17 put: Message;
 		at: 18 put: Symbol;
-		at: 19 put: Smalltalk;
+		at: 19 put: Smalltalk globals;
 		at: 20 put: MessageSend;
 		at: 22 put: Processor;
 		at: 26 put: Class;


### PR DESCRIPTION
This PR makes sure that ODBSystemDictionaryCode de-serializes as the dictionary, not the instance of SmalltalkImage.

(if needed, we might add a special serializer for SmalltalkImage instances in addition later)

fixes #26