### PR TITLE
24-Serializer-Implement-Boxed-Float-Serialization

### DIFF
--- a/src/OmniBase-Tests/ODBSerializationTest.class.st
+++ b/src/OmniBase-Tests/ODBSerializationTest.class.st
@@ -58,14 +58,19 @@ ODBSerializationTest >> testSerializationBoxedFloat64 [
 	self assert: float class equals: BoxedFloat64.
 	serialized := ODBSerializer serializeToBytes: float.
 	self 
-		assert: serialized 
-		equals: #[0 1 12 66 111 120 101 100 70 108 111 97 116 54 52 1 1 0 1 0 0 0 2 1 2 128 128 224 234 6 0].
-	"self assert: (serialized at: 7) equals: ODBFloatCode."
-	self flag: #TODO. "Implement BoxedFloat Serialisation and de-serialization"
+		assert: serialized
+		equals: #[0 0 0 0 0 0 40 128 128 224 234 6 0].
+	self assert: (serialized at: 7) equals: ODBFloatCode.
 	
 	materialized := ODBDeserializer deserializeFromBytes: serialized.
 	self assert: float class equals: BoxedFloat64.
-	self assert: materialized equals: 2.45227231256843e-45
+	self assert: materialized equals: 2.45227231256843e-45.
+	
+	"can we still de-serialize the old way before we used ODBFloatCode?"
+	materialized := ODBDeserializer deserializeFromBytes: 
+	#[0 1 12 66 111 120 101 100 70 108 111 97 116 54 52 1 1 0 1 0 0 0 2 1 2 128 128 224 234 6 0].
+	self assert: float class equals: BoxedFloat64.
+	self assert: materialized equals: 2.45227231256843e-45.
 
 ]
 

--- a/src/OmniBase-Tests/ODBSerializationTest.class.st
+++ b/src/OmniBase-Tests/ODBSerializationTest.class.st
@@ -63,13 +63,13 @@ ODBSerializationTest >> testSerializationBoxedFloat64 [
 	self assert: (serialized at: 7) equals: ODBFloatCode.
 	
 	materialized := ODBDeserializer deserializeFromBytes: serialized.
-	self assert: float class equals: BoxedFloat64.
+	self assert: materialized class equals: BoxedFloat64.
 	self assert: materialized equals: 2.45227231256843e-45.
 	
 	"can we still de-serialize the old way before we used ODBFloatCode?"
 	materialized := ODBDeserializer deserializeFromBytes: 
 	#[0 1 12 66 111 120 101 100 70 108 111 97 116 54 52 1 1 0 1 0 0 0 2 1 2 128 128 224 234 6 0].
-	self assert: float class equals: BoxedFloat64.
+	self assert: materialized class equals: BoxedFloat64.
 	self assert: materialized equals: 2.45227231256843e-45.
 
 ]

--- a/src/OmniBase/BoxedFloat64.extension.st
+++ b/src/OmniBase/BoxedFloat64.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #BoxedFloat64 }
+
+{ #category : #'*OmniBase' }
+BoxedFloat64 >> odbBasicSerialize: serializer [ 
+	serializer stream
+		putByte: 40;
+		putInteger: (self at: 1);
+		putInteger: (self at: 2)
+]
+
+{ #category : #'*OmniBase' }
+BoxedFloat64 >> odbSerialize: serializer [
+
+	self odbBasicSerialize: serializer
+]

--- a/src/OmniBase/ODBTypeCodes.class.st
+++ b/src/OmniBase/ODBTypeCodes.class.st
@@ -111,7 +111,6 @@ ODBTypeCodes class >> initializeTypeCodes [
 	ODBFloatAsIntegerCode := 43.
 	ODBFloatAs100IntegerCode := 44.
 	ODBScaledDecimalCode := 45.
-	ODBFloatCode := 46.
 	ODBSmallFloat64Code := 47.
 	"integers <= 16 are stored with code 50 + number"
 	ODBSmallPositiveIntegerBaseCode := 50. 


### PR DESCRIPTION
This PR implements serialization for BoxedFloats64, until know they have been saved as normal Objects, which wastes space.

-  in #initializeTypeCodes, we had two definition for ODBFloatCode, remove 46 and keep 40
- fix testSerializationBoxedFloat64
- implemet serialization.

Deserialisation is implemented in Float and used by both.

This is backward compatible, that is, we can still read Floats already stored in a database
(see end of testSerializationBoxedFloat64)