### PR TITLE
[Trival] Cleanup whitespace end of methods

### DIFF
--- a/src/OmniBase-Tests/Account.class.st
+++ b/src/OmniBase-Tests/Account.class.st
@@ -18,14 +18,14 @@ Account >> balance: anInteger [
 	balance := anInteger
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 Account >> decrement: anInteger [ 
-	balance := balance - anInteger 
+	balance := balance - anInteger
 ]
 
 { #category : #accessing }
 Account >> increment: anInteger [ 
-	balance := balance + anInteger 
+	balance := balance + anInteger
 ]
 
 { #category : #transferring }

--- a/src/OmniBase-Tests/ODBClassDescriptionTest.class.st
+++ b/src/OmniBase-Tests/ODBClassDescriptionTest.class.st
@@ -17,7 +17,5 @@ ODBClassDescriptionTest >> testReshape [
 		"addInstVarNamed: 'four';"
 		addInstVarNamed: 'two'.
 	self assertCollection: tmpClass instVarNames hasSameElements: #( one three two).
-	desc2 := ODBClassDescription new createFor: tmpClass. 
-
-		
+	desc2 := ODBClassDescription new createFor: tmpClass.
 ]

--- a/src/OmniBase-Tests/ODBCleanCodeTest.class.st
+++ b/src/OmniBase-Tests/ODBCleanCodeTest.class.st
@@ -7,6 +7,25 @@ Class {
 	#category : #'OmniBase-Tests'
 }
 
+{ #category : #cleanup }
+ODBCleanCodeTest class >> cleanupWhiteSpaceTrimRight [
+	<script>
+	| badCases |
+	badCases := (OmniBase package methods, self package methods) select: [ :each | 
+		            each sourceCode trimRight size ~= each sourceCode size ].
+
+	badCases do: [ :each | 
+		| refactoring classOrTrait |
+		classOrTrait := each traitSource
+			                ifNil: [ each methodClass ]
+			                ifNotNil: [ each traitSource innerClass ].
+		refactoring := RBAddMethodChange
+			               compile: each sourceCode trimRight
+			               in: classOrTrait
+			               for: nil.
+		refactoring execute ]
+]
+
 { #category : #tests }
 ODBCleanCodeTest >> testNoDuplicatedMethodInHierarchy [
 	"There should be no methods in the hierachy that are already in a superclass"

--- a/src/OmniBase-Tests/ODBDatabaseTest.class.st
+++ b/src/OmniBase-Tests/ODBDatabaseTest.class.st
@@ -94,7 +94,6 @@ ODBDatabaseTest >> testGC [
 	"Test garbage collection"
 	self timeLimit: 1 minute. 
 	"self shouldnt: [" db garbageCollect "] raise: Error."
-
 ]
 
 { #category : #tests }
@@ -143,7 +142,6 @@ ODBDatabaseTest >> testMakePersistent [
 	txn := db newTransaction.
 	txn makePersistent: self collection.
 	txn commit.
-	
 ]
 
 { #category : #tests }
@@ -164,7 +162,6 @@ ODBDatabaseTest >> testNewPersistent [
 ODBDatabaseTest >> testNoClientsAfterCreation [
 
 	self assert: db numberOfClients equals: 0.
-	
 ]
 
 { #category : #tests }
@@ -217,7 +214,6 @@ ODBDatabaseTest >> testOneClientAfterOpening [
 	| client |
 	client := db localClient.
 	self assert: db numberOfClients equals: 1.
-	
 ]
 
 { #category : #tests }
@@ -234,7 +230,6 @@ ODBDatabaseTest >> testPersistTwoObjectsInCluster [
 	
 	self assert: txn changesPackage changes size equals: 1.
 	txn abort.
-	
 ]
 
 { #category : #tests }
@@ -252,7 +247,6 @@ ODBDatabaseTest >> testPersistTwoObjectsSeparate [
 	
 	self assert: txn changesPackage changes size equals: 2.
 	txn abort.
-	
 ]
 
 { #category : #tests }
@@ -270,7 +264,6 @@ ODBDatabaseTest >> testPersistTwoObjectsWithCollectionInCluster [
 	
 	self assert: txn changesPackage changes size equals: 1.
 	txn abort.
-	
 ]
 
 { #category : #tests }
@@ -290,7 +283,6 @@ ODBDatabaseTest >> testPersistTwoObjectsWithCollectionSeparate [
 	
 	self assert: txn changesPackage changes size equals: 2.
 	txn abort.
-	
 ]
 
 { #category : #tests }
@@ -313,7 +305,6 @@ ODBDatabaseTest >> testPersistTwoObjectsWithDictionaryInCluster [
 	
 	self assert: txn changesPackage changes size equals: 2.
 	txn abort.
-	
 ]
 
 { #category : #tests }
@@ -337,5 +328,4 @@ ODBDatabaseTest >> testPersistTwoObjectsWithODBDictionary [
 	
 	self assert: txn changesPackage changes size equals: 3.
 	txn abort.
-	
 ]

--- a/src/OmniBase-Tests/ODBDiskBasedTest.class.st
+++ b/src/OmniBase-Tests/ODBDiskBasedTest.class.st
@@ -42,5 +42,5 @@ ODBDiskBasedTest >> setUp [
 ODBDiskBasedTest >> tearDown [
 	db ifNotNil: [ db close ].
 	ODBLockRegistry reset.
-	self deleteDatabaseOnFileSystem 
+	self deleteDatabaseOnFileSystem
 ]

--- a/src/OmniBase-Tests/ODBLockRegistryTest.class.st
+++ b/src/OmniBase-Tests/ODBLockRegistryTest.class.st
@@ -57,5 +57,5 @@ ODBLockRegistryTest >> testRegisterByOpeningDatabase [
 	Smalltalk garbageCollect .
 	Smalltalk garbageCollect .
 	Smalltalk garbageCollect .
-	self assert: ODBLockRegistry registeredPaths size equals: 0 
+	self assert: ODBLockRegistry registeredPaths size equals: 0
 ]

--- a/src/OmniBase-Tests/ODBPersistentDictionaryTest.class.st
+++ b/src/OmniBase-Tests/ODBPersistentDictionaryTest.class.st
@@ -11,8 +11,6 @@ ODBPersistentDictionaryTest >> testAdd [
 		add: (#test -> true);
 		yourself] evaluateAndCommitIn: db newTransaction.
 	self assert: (dict at: #test)
-	
-
 ]
 
 { #category : #tests }
@@ -32,8 +30,6 @@ ODBPersistentDictionaryTest >> testNewPersistentDictionary [
 		yourself.
 	dict := dict asDictionary ] evaluateAndCommitIn: db newTransaction.
 	self assert: (dict at: #test)
-	
-
 ]
 
 { #category : #tests }
@@ -49,8 +45,6 @@ ODBPersistentDictionaryTest >> testRemoveKeyifAbsent [
 		] evaluateAndCommitIn: db newTransaction.
 	self assert: (dict at: #tt).
 	self assert: tag
-	
-
 ]
 
 { #category : #tests }
@@ -63,6 +57,4 @@ ODBPersistentDictionaryTest >> testTransaction [
 		self assert: dict transaction equals: transaction.	
 		] evaluateAndCommitIn: transaction.
 	self assert: (dict at: #test)
-	
-
 ]

--- a/src/OmniBase-Tests/ODBSerializationTest.class.st
+++ b/src/OmniBase-Tests/ODBSerializationTest.class.st
@@ -78,7 +78,6 @@ ODBSerializationTest >> testSerializationBoxedFloat64 [
 	#[0 1 12 66 111 120 101 100 70 108 111 97 116 54 52 1 1 0 1 0 0 0 2 1 2 128 128 224 234 6 0].
 	self assert: materialized class equals: BoxedFloat64.
 	self assert: materialized equals: 2.45227231256843e-45.
-
 ]
 
 { #category : #tests }
@@ -309,7 +308,6 @@ ODBSerializationTest >> testSerializationSmallFloat64 [
 	materialized := ODBDeserializer deserializeFromBytes: serialized.
 	self assert: materialized class equals: SmallFloat64.
 	self assert: materialized equals: 1.11
-
 ]
 
 { #category : #tests }
@@ -446,7 +444,6 @@ ODBSerializationTest >> testSerializationWideStringUTF16 [
 
 	materialized := ODBDeserializer deserializeFromBytes: serialized.
 	self assert: materialized equals: string.
-
 ]
 
 { #category : #tests }
@@ -467,7 +464,6 @@ ODBSerializationTest >> testSerializationWideStringUTF32 [
 	
 	materialized := ODBDeserializer deserializeFromBytes: serialized.
 	self assert: materialized equals: string.
-
 ]
 
 { #category : #tests }
@@ -487,5 +483,4 @@ ODBSerializationTest >> testSerializationWideStringUTF8 [
 
 	materialized := ODBDeserializer deserializeFromBytes: serialized.
 	self assert: materialized equals: string.
-
 ]

--- a/src/OmniBase-Tests/ODBTransactionTest.class.st
+++ b/src/OmniBase-Tests/ODBTransactionTest.class.st
@@ -56,7 +56,6 @@ ODBTransactionTest >> testReadOnlyTransaction [
 	balanceB := ((transaction root at: 'Accounts') at: 'B') balance.
 	"should be still the old value as the re-only transaction should have no impact"
 	self assert: balanceB equals: 200.
-
 ]
 
 { #category : #tests }
@@ -75,7 +74,6 @@ ODBTransactionTest >> testReferenceToSecondContainer [
 	transaction2 := db newTransaction. 
 	self assert: (transaction2 root at: 'test1') first isODBReference.
 	self assert: (db containerNamed: 'second' ifAbsent: [self error]) numberOfObjects equals: 1.
-	
 ]
 
 { #category : #tests }
@@ -108,5 +106,4 @@ ODBTransactionTest >> testTransactionPreservesState [
 	"should be still the old value as the transaction should snapshot data to the time 
 	of transaction creation"
 	self assert: balanceB equals: 200
-
 ]

--- a/src/OmniBase/Array.extension.st
+++ b/src/OmniBase/Array.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #Array }
 { #category : #'*omnibase' }
 Array >> odbBasicSerialize: serializer [
 
-	serializer stream nextPutArray: self 
+	serializer stream nextPutArray: self
 ]
 
 { #category : #'*omnibase' }

--- a/src/OmniBase/Association.extension.st
+++ b/src/OmniBase/Association.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #Association }
 { #category : #'*omnibase' }
 Association >> odbBasicSerialize: serializer [
 
-	serializer stream nextPutAssociation: self 
+	serializer stream nextPutAssociation: self
 ]
 
 { #category : #'*omnibase' }

--- a/src/OmniBase/BSDFLock.class.st
+++ b/src/OmniBase/BSDFLock.class.st
@@ -175,7 +175,6 @@ BSDFLock class >> setNonBlock: fileHandle [
 	
 	flags := self fcntl: fd command: F_GETFL value: 0.
 	flags := self fcntl: fd command: F_SETFL value: flags | O_NONBLOCK
-	
 ]
 
 { #category : #'accessing locking' }

--- a/src/OmniBase/BoxedFloat64.extension.st
+++ b/src/OmniBase/BoxedFloat64.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #BoxedFloat64 }
 
 { #category : #'*OmniBase' }
 BoxedFloat64 >> odbBasicSerialize: serializer [ 
-	serializer stream nextPutBoxedFloat64: self 
+	serializer stream nextPutBoxedFloat64: self
 ]
 
 { #category : #'*OmniBase' }

--- a/src/OmniBase/ByteArray.extension.st
+++ b/src/OmniBase/ByteArray.extension.st
@@ -30,7 +30,7 @@ ByteArray >> odbAsInteger [
 { #category : #'*OmniBase' }
 ByteArray >> odbBasicSerialize: serializer [
 
-	serializer stream nextPutByteArray: self 
+	serializer stream nextPutByteArray: self
 ]
 
 { #category : #'*OmniBase' }

--- a/src/OmniBase/Character.extension.st
+++ b/src/OmniBase/Character.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #Character }
 { #category : #'*omnibase' }
 Character >> odbBasicSerialize: serializer [
 
-	serializer stream nextPutCharacter: self 
+	serializer stream nextPutCharacter: self
 ]
 
 { #category : #'*omnibase' }

--- a/src/OmniBase/Class.extension.st
+++ b/src/OmniBase/Class.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #Class }
 { #category : #'*omnibase' }
 Class >> odbBasicSerialize: serializer [
 
-	serializer stream nextPutClass: self 
+	serializer stream nextPutClass: self
 ]
 
 { #category : #'*omnibase' }

--- a/src/OmniBase/Date.extension.st
+++ b/src/OmniBase/Date.extension.st
@@ -23,5 +23,5 @@ Date class >> odbDateFromSeconds: seconds offset: offset [
 { #category : #'*omnibase' }
 Date class >> odbDeserialize: deserializer [
 
-	^ deserializer stream nextDate: self 
+	^ deserializer stream nextDate: self
 ]

--- a/src/OmniBase/Dictionary.extension.st
+++ b/src/OmniBase/Dictionary.extension.st
@@ -3,11 +3,11 @@ Extension { #name : #Dictionary }
 { #category : #'*omnibase' }
 Dictionary >> odbBasicSerialize: serializer [
 
-	serializer stream nextPutDictionary: self 
+	serializer stream nextPutDictionary: self
 ]
 
 { #category : #'*omnibase' }
 Dictionary class >> odbDeserialize: deserializer [
 
-	^ deserializer stream nextDictionary: self 
+	^ deserializer stream nextDictionary: self
 ]

--- a/src/OmniBase/FLock.class.st
+++ b/src/OmniBase/FLock.class.st
@@ -179,7 +179,6 @@ FLock class >> setNonBlock: fileHandle [
 	
 	flags := self fcntl: fd command: F_GETFL value: 0.
 	flags := self fcntl: fd command: F_SETFL value: flags | O_NONBLOCK
-	
 ]
 
 { #category : #'accessing locking' }

--- a/src/OmniBase/False.extension.st
+++ b/src/OmniBase/False.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #False }
 { #category : #'*omnibase' }
 False >> odbBasicSerialize: serializer [
 
-	serializer stream nextPutFalse: self 
+	serializer stream nextPutFalse: self
 ]
 
 { #category : #'*omnibase' }

--- a/src/OmniBase/Float.extension.st
+++ b/src/OmniBase/Float.extension.st
@@ -9,5 +9,5 @@ Float >> asBtreeKeyOfSize: keySize [
 { #category : #'*omnibase' }
 Float class >> odbDeserialize: deserializer [
 
-	^ deserializer stream nextSmallFloat64: deserializer 
+	^ deserializer stream nextSmallFloat64: deserializer
 ]

--- a/src/OmniBase/Fraction.extension.st
+++ b/src/OmniBase/Fraction.extension.st
@@ -3,13 +3,13 @@ Extension { #name : #Fraction }
 { #category : #'*omnibase' }
 Fraction >> odbBasicSerialize: serializer [
 
-	serializer stream nextPutFraction: self 
+	serializer stream nextPutFraction: self
 ]
 
 { #category : #'*omnibase' }
 Fraction class >> odbDeserialize: deserializer [
 
-	^ deserializer stream nextFraction: self 
+	^ deserializer stream nextFraction: self
 ]
 
 { #category : #'*omnibase' }

--- a/src/OmniBase/IdentityDictionary.extension.st
+++ b/src/OmniBase/IdentityDictionary.extension.st
@@ -3,5 +3,5 @@ Extension { #name : #IdentityDictionary }
 { #category : #'*omnibase' }
 IdentityDictionary >> odbBasicSerialize: serializer [
 
-	serializer stream nextPutIdentityDictionary: self 
+	serializer stream nextPutIdentityDictionary: self
 ]

--- a/src/OmniBase/Integer.extension.st
+++ b/src/OmniBase/Integer.extension.st
@@ -27,7 +27,7 @@ Integer >> asBtreeKeyOfSize: keySize [
 { #category : #'*omnibase' }
 Integer >> odbBasicSerialize: serializer [
 
-	serializer stream nextPutInteger: self 
+	serializer stream nextPutInteger: self
 ]
 
 { #category : #'*omnibase' }

--- a/src/OmniBase/MacOSPlatform.extension.st
+++ b/src/OmniBase/MacOSPlatform.extension.st
@@ -2,5 +2,5 @@ Extension { #name : #MacOSPlatform }
 
 { #category : #'*OmniBase' }
 MacOSPlatform >> flockClass [
-	^ BSDFLock 
+	^ BSDFLock
 ]

--- a/src/OmniBase/Message.extension.st
+++ b/src/OmniBase/Message.extension.st
@@ -3,11 +3,11 @@ Extension { #name : #Message }
 { #category : #'*omnibase' }
 Message >> odbBasicSerialize: serializer [ 
 	
-	serializer stream nextPutMessage: self 
+	serializer stream nextPutMessage: self
 ]
 
 { #category : #'*omnibase' }
 Message class >> odbDeserialize: deserializer [ 
 	
-	^ deserializer stream nextMessage: self  
+	^ deserializer stream nextMessage: self
 ]

--- a/src/OmniBase/MessageSend.extension.st
+++ b/src/OmniBase/MessageSend.extension.st
@@ -9,5 +9,5 @@ MessageSend >> odbBasicSerialize: serializer [
 { #category : #'*omnibase' }
 MessageSend class >> odbDeserialize: deserializer [ 
 
-	^ deserializer stream nextMessageSend: self  
+	^ deserializer stream nextMessageSend: self
 ]

--- a/src/OmniBase/ODBBTreeIndexDictionary.class.st
+++ b/src/OmniBase/ODBBTreeIndexDictionary.class.st
@@ -390,7 +390,7 @@ ODBBTreeIndexDictionary >> keyLength [
 { #category : #accessing }
 ODBBTreeIndexDictionary >> keySize [ 
 
-	^ keySize 
+	^ keySize
 ]
 
 { #category : #private }

--- a/src/OmniBase/ODBChange.class.st
+++ b/src/OmniBase/ODBChange.class.st
@@ -29,8 +29,6 @@ ODBChange >> committed [
 { #category : #public }
 ODBChange >> loadFromStream: aStream [ 
 	"Load receiver from aStream.  Implemented by subclasses."
-
-	
 ]
 
 { #category : #accessing }

--- a/src/OmniBase/ODBEncodingStream.class.st
+++ b/src/OmniBase/ODBEncodingStream.class.st
@@ -27,7 +27,7 @@ ODBEncodingStream class >> characterEncoding: aString [
 
 { #category : #convenience }
 ODBEncodingStream class >> decodeBytes: aByteArray [ 
-	^ characterEncoder decodeBytes: aByteArray 
+	^ characterEncoder decodeBytes: aByteArray
 ]
 
 { #category : #convenience }
@@ -37,7 +37,7 @@ ODBEncodingStream class >> encodeString: aString [
 
 { #category : #initialization }
 ODBEncodingStream class >> initialize [ 
-	self initializeEncoding 
+	self initializeEncoding
 ]
 
 { #category : #initialization }
@@ -158,13 +158,13 @@ ODBEncodingStream >> getBytesFor: aByteCollection len: len [
 	"Read len bytes from stream to aByteCollection. 
 	Answer number of bytes actualy read."
 	
-	^ stream getBytesFor: aByteCollection len: len 
+	^ stream getBytesFor: aByteCollection len: len
 ]
 
 { #category : #accessing }
 ODBEncodingStream >> lockAt: position length: length [ 
 
-	^ stream lockAt: position length: length 
+	^ stream lockAt: position length: length
 ]
 
 { #category : #reading }
@@ -213,8 +213,7 @@ ODBEncodingStream >> nextClass [
 ODBEncodingStream >> nextDate: aClass [
 	^ readerWriter register: (aClass 
 		odbDateFromSeconds: stream getInteger 
-		offset: stream getInteger) 
-		
+		offset: stream getInteger)
 ]
 
 { #category : #reading }
@@ -399,7 +398,7 @@ ODBEncodingStream >> nextPutDictionary: aDictionary [
 ODBEncodingStream >> nextPutExternalReference: anObjectID [ 
 	stream
 		putByte: ODBExternalReferenceCode;
-		putPositiveInteger: anObjectID 
+		putPositiveInteger: anObjectID
 ]
 
 { #category : #writing }
@@ -469,7 +468,7 @@ ODBEncodingStream >> nextPutMessageSend: aMessageSend [
 
 { #category : #writing }
 ODBEncodingStream >> nextPutNil: anUndefinedObject [ 
-	stream putByte: ODBUndefinedObjectCode 
+	stream putByte: ODBUndefinedObjectCode
 ]
 
 { #category : #writing }
@@ -492,7 +491,7 @@ ODBEncodingStream >> nextPutPersistentDictionary: aPersistentDictionary [
 
 { #category : #writing }
 ODBEncodingStream >> nextPutProcessorScheduler: aProcessorScheduler [ 
-	stream putByte: ODBProcessSchedulerCode 
+	stream putByte: ODBProcessSchedulerCode
 ]
 
 { #category : #writing }
@@ -500,7 +499,7 @@ ODBEncodingStream >> nextPutSmallFloat64: aNumber [
 	stream
 		putByte: ODBSmallFloat64Code;
 		putInteger: (aNumber at: 1);
-		putInteger: (aNumber at: 2)  
+		putInteger: (aNumber at: 2)
 ]
 
 { #category : #writing }
@@ -527,7 +526,7 @@ ODBEncodingStream >> nextPutSymbol: aSymbol [
 
 { #category : #writing }
 ODBEncodingStream >> nextPutSystemDictionary: aCollection [ 
-	stream putByte: ODBSystemDictionaryCode 
+	stream putByte: ODBSystemDictionaryCode
 ]
 
 { #category : #writing }
@@ -539,7 +538,7 @@ ODBEncodingStream >> nextPutTime: aTime [
 
 { #category : #writing }
 ODBEncodingStream >> nextPutTransaction: aTransaction [ 
-	stream putByte: ODBTransactionCode 
+	stream putByte: ODBTransactionCode
 ]
 
 { #category : #writing }
@@ -581,7 +580,6 @@ ODBEncodingStream >> nextString: aDeserializer [
 	string := buf asString.
 	aDeserializer register: string.
 	^ string
-
 ]
 
 { #category : #reading }
@@ -614,12 +612,12 @@ ODBEncodingStream >> nextnCharacterString: aDeserializer size: size [
 
 { #category : #accessing }
 ODBEncodingStream >> position: anInteger [ 
-	^ stream position: anInteger 
+	^ stream position: anInteger
 ]
 
 { #category : #accessing }
 ODBEncodingStream >> primitive [
-	^ stream 
+	^ stream
 ]
 
 { #category : #public }
@@ -631,7 +629,7 @@ ODBEncodingStream >> putBytesFrom: aByteCollection len: len [
 
 { #category : #accessing }
 ODBEncodingStream >> readerWriter: anODBSerializer [ 
-	readerWriter := anODBSerializer 
+	readerWriter := anODBSerializer
 ]
 
 { #category : #removing }
@@ -661,11 +659,11 @@ ODBEncodingStream >> truncate: anInteger [
 	"Truncate stream so that its size will be anInteger. 
 	Position to anInteger."
 
-	stream truncate: anInteger 
+	stream truncate: anInteger
 ]
 
 { #category : #accessing }
 ODBEncodingStream >> unlockAt: position length: length [
 
-	^ stream unlockAt: position length: length 
+	^ stream unlockAt: position length: length
 ]

--- a/src/OmniBase/ODBExpiredProxyObject.class.st
+++ b/src/OmniBase/ODBExpiredProxyObject.class.st
@@ -28,8 +28,7 @@ ODBExpiredProxyObject >> doesNotUnderstand: aMessage [
 			self becomeForward: freshTarget.
 			freshTarget 
 				perform: aMessage selector
-				withArguments: aMessage arguments]. 
-
+				withArguments: aMessage arguments].
 ]
 
 { #category : #public }

--- a/src/OmniBase/ODBFile.class.st
+++ b/src/OmniBase/ODBFile.class.st
@@ -104,7 +104,6 @@ ODBFile >> headerLength [
 ODBFile >> newCodecStreamOn: aFileReference [
 
 	^ (File named: aFileReference pathString) openForWrite asODBPrimitiveEncodingStream.
-
 ]
 
 { #category : #'create/open/close' }
@@ -114,7 +113,6 @@ ODBFile >> newCodecStreamOn: aFileReference using: aBlock [
 	[ aBlock cull: fileStream ]
 		ifCurtailed: [ fileStream close. ^ nil ].
 	^ fileStream asODBPrimitiveEncodingStream.
-
 ]
 
 { #category : #'create/open/close' }
@@ -196,8 +194,7 @@ ODBFile >> waitForAddingLock [
 
 	^ self
 		waitForLockAt: 0 
-		length: 1 
-
+		length: 1
 ]
 
 { #category : #public }

--- a/src/OmniBase/ODBFileStreamWrapper.class.st
+++ b/src/OmniBase/ODBFileStreamWrapper.class.st
@@ -111,7 +111,6 @@ ODBFileStreamWrapper >> basicPutBytesFrom: aByteArray len: length [
 		= length ifFalse: [OmniBase signalError: 'Could not write the whole data'].
 	stream flush.
 	^self
-
 ]
 
 { #category : #'initialize-release' }
@@ -197,13 +196,13 @@ ODBFileStreamWrapper >> getWord [
 { #category : #initialization }
 ODBFileStreamWrapper >> initialize [ 
 	super initialize.
-	mutex := Semaphore forMutualExclusion 
+	mutex := Semaphore forMutualExclusion
 ]
 
 { #category : #public }
 ODBFileStreamWrapper >> lockAt: position length: length [ 
 
-	^ stream lockAt: position length: length 
+	^ stream lockAt: position length: length
 ]
 
 { #category : #accessing }
@@ -270,12 +269,12 @@ ODBFileStreamWrapper >> remove [
 ODBFileStreamWrapper >> setToEnd [
 	^ stream 
 		setToEnd;
-		position 
+		position
 ]
 
 { #category : #accessing }
 ODBFileStreamWrapper >> stream: aFileStream [ 
-	stream := aFileStream 
+	stream := aFileStream
 ]
 
 { #category : #accessing }
@@ -296,5 +295,5 @@ ODBFileStreamWrapper >> unlock [
 { #category : #accessing }
 ODBFileStreamWrapper >> unlockAt: position length: length [
 
-	^ stream unlockAt: position length: length 
+	^ stream unlockAt: position length: length
 ]

--- a/src/OmniBase/ODBGarbageCollector.class.st
+++ b/src/OmniBase/ODBGarbageCollector.class.st
@@ -309,7 +309,6 @@ ODBGarbageCollector >> walkObjectReferencesOf: objectID addInto: firstToDo oidSe
 						firstToDo add: oid.
 						progressBlock value ] ].
 			dbObject close ]
-
 ]
 
 { #category : #private }

--- a/src/OmniBase/ODBIdentityDictionary.class.st
+++ b/src/OmniBase/ODBIdentityDictionary.class.st
@@ -26,7 +26,7 @@ ODBIdentityDictionary class >> new: anInteger [
 { #category : #public }
 ODBIdentityDictionary class >> odbDeserialize: deserializer [ 
 
-	^ deserializer stream nextODBIdentityDictionary:  self 
+	^ deserializer stream nextODBIdentityDictionary:  self
 ]
 
 { #category : #public }

--- a/src/OmniBase/ODBLocalTransaction.class.st
+++ b/src/OmniBase/ODBLocalTransaction.class.st
@@ -27,7 +27,6 @@ ODBLocalTransaction >> addLoggedLock: aKeyLock [
 	locks add: aKeyLock.
 	transactionFile lockAdd: aKeyLock.
 	^ true
-	
 ]
 
 { #category : #public }
@@ -111,8 +110,7 @@ ODBLocalTransaction >> hasForeignLockFor: aTransactionObject [
 ODBLocalTransaction >> hasKeyLockOn: aBtreeDictionary key: aCollection [ 
 	^ lockRegistry 
 		hasKeyLockOn: aBtreeDictionary 
-		key: aCollection 
-
+		key: aCollection
 ]
 
 { #category : #testing }
@@ -150,7 +148,6 @@ ODBLocalTransaction >> isPersistent: anObject [
 	"Answers true if anObject is persistent, false otherwise."
 	
 	^ (self getTransactionObject: anObject ifAbsent:[nil]) notNil
-	
 ]
 
 { #category : #testing }

--- a/src/OmniBase/ODBLock.class.st
+++ b/src/OmniBase/ODBLock.class.st
@@ -20,7 +20,7 @@ ODBLock class >> lockClassID [
 
 { #category : #testing }
 ODBLock >> isSameTransaction: anODBLocalTransaction [ 
-	^ transaction = anODBLocalTransaction 
+	^ transaction = anODBLocalTransaction
 ]
 
 { #category : #'public/accessing' }
@@ -49,7 +49,7 @@ ODBLock >> lockIndex: anInteger [
 
 { #category : #'public/accessing' }
 ODBLock >> lockRegistryKey [ 
-	^ objectID lockRegistryKey 
+	^ objectID lockRegistryKey
 ]
 
 { #category : #'public/accessing' }

--- a/src/OmniBase/ODBLockRegistry.class.st
+++ b/src/OmniBase/ODBLockRegistry.class.st
@@ -32,7 +32,7 @@ ODBLockRegistry class >> forPath: aFileReference [
 	^ registries 
 		at: path 
 		ifAbsentPut: [ 
-			self new path: path  ] 
+			self new path: path  ]
 ]
 
 { #category : #'class initialization' }
@@ -47,20 +47,19 @@ ODBLockRegistry class >> registeredPaths [
 
 { #category : #accessing }
 ODBLockRegistry class >> registries [ 
-	^ registries 
+	^ registries
 ]
 
 { #category : #removing }
 ODBLockRegistry class >> remove: aRegistry [ 
 	^ registries 
 		removeKey: aRegistry path 
-		ifAbsent: [ ] 
+		ifAbsent: [ ]
 ]
 
 { #category : #removing }
 ODBLockRegistry class >> removePath: aString [ 
-	^ registries removeKey: aString 
-	
+	^ registries removeKey: aString
 ]
 
 { #category : #'class initialization' }
@@ -72,7 +71,7 @@ ODBLockRegistry class >> reset [
 ODBLockRegistry >> addLock: aKeyLock [ 
 	^ self 
 		lockAt: aKeyLock lockRegistryKey 
-		put: aKeyLock 
+		put: aKeyLock
 ]
 
 { #category : #removing }
@@ -138,7 +137,7 @@ ODBLockRegistry >> path [
 
 { #category : #accessing }
 ODBLockRegistry >> path: aFileReference [ 
-	path := aFileReference 
+	path := aFileReference
 ]
 
 { #category : #removing }
@@ -152,7 +151,7 @@ ODBLockRegistry >> removeLock: anODBObjectLock [
 		locks 
 			removeKey: anODBObjectLock lockRegistryKey 
 			ifAbsent: [  ] ].
-	self checkRemoval 
+	self checkRemoval
 ]
 
 { #category : #initialization }

--- a/src/OmniBase/ODBMemoryStreamWrapper.class.st
+++ b/src/OmniBase/ODBMemoryStreamWrapper.class.st
@@ -26,8 +26,7 @@ ODBMemoryStreamWrapper >> createOn: aByteArray [
 ]
 
 { #category : #accessing }
-ODBMemoryStreamWrapper >> flush [ 
-
+ODBMemoryStreamWrapper >> flush [
 ]
 
 { #category : #public }
@@ -94,7 +93,7 @@ ODBMemoryStreamWrapper >> putWord: anInteger [
 
 { #category : #accessing }
 ODBMemoryStreamWrapper >> stream: aCollection [ 
-	stream := aCollection 
+	stream := aCollection
 ]
 
 { #category : #writing }

--- a/src/OmniBase/ODBPrimitiveEncodingStream.class.st
+++ b/src/OmniBase/ODBPrimitiveEncodingStream.class.st
@@ -20,7 +20,7 @@ ODBPrimitiveEncodingStream >> getBoolean [
 
 { #category : #public }
 ODBPrimitiveEncodingStream >> getByte [
-	self subclassResponsibility 
+	self subclassResponsibility
 ]
 
 { #category : #public }
@@ -31,7 +31,7 @@ ODBPrimitiveEncodingStream >> getBytesFor: aByteCollection [
 
 { #category : #public }
 ODBPrimitiveEncodingStream >> getBytesFor: bytes len: size [
-	self subclassResponsibility 
+	self subclassResponsibility
 ]
 
 { #category : #public }

--- a/src/OmniBase/ODBReference.class.st
+++ b/src/OmniBase/ODBReference.class.st
@@ -54,7 +54,6 @@ ODBReference >> isIdenticalTo: anObject [
 { #category : #hacks }
 ODBReference >> isMorph [
 	^ false
-
 ]
 
 { #category : #public }
@@ -73,8 +72,6 @@ ODBReference >> isODBReference [
 { #category : #accessing }
 ODBReference >> makePersistent [
 	"Do nothing, object is already persistent."
-
-	
 ]
 
 { #category : #accessing }

--- a/src/OmniBase/ODBTransaction.class.st
+++ b/src/OmniBase/ODBTransaction.class.st
@@ -29,7 +29,6 @@ ODBTransaction >> abort [
 	transactionManager isNil ifFalse: [transactionManager critical: [self basicAbort]].
 
 	self triggerEvent: #finishedTransaction: with: self.
-
 ]
 
 { #category : #public }
@@ -262,7 +261,7 @@ ODBTransaction >> objectHolderAt: objectID [
 { #category : #'private/unclassified' }
 ODBTransaction >> odbBasicSerialize: serializer [
 
-	serializer stream nextPutTransaction: self 
+	serializer stream nextPutTransaction: self
 ]
 
 { #category : #'private/unclassified' }

--- a/src/OmniBase/ODBTransactionObject.class.st
+++ b/src/OmniBase/ODBTransactionObject.class.st
@@ -65,14 +65,12 @@ ODBTransactionObject >> lock [
 
 { #category : #accessing }
 ODBTransactionObject >> lockRegistryKey [
-	^ self objectID lockRegistryKey 
+	^ self objectID lockRegistryKey
 ]
 
 { #category : #public }
 ODBTransactionObject >> objectChanged [
 	"This message is sent from transaction the first time it is marked as dirty."
-
-	
 ]
 
 { #category : #public }
@@ -95,15 +93,11 @@ ODBTransactionObject >> objectID [
 { #category : #public }
 ODBTransactionObject >> objectLoaded [
 	"Sent to transaction object when it is loaded into transaction."
-
-	
 ]
 
 { #category : #public }
 ODBTransactionObject >> objectStored [
 	"Sent to transaction object when it is stored for the first time."
-
-	
 ]
 
 { #category : #printing }

--- a/src/OmniBase/ODBTypeCodes.class.st
+++ b/src/OmniBase/ODBTypeCodes.class.st
@@ -51,8 +51,7 @@ Class {
 { #category : #initialization }
 ODBTypeCodes class >> initialize [ 
 	self initializeTypeCodes.
-	ODBEncodingStream initializeTypeCodeMapping 
-
+	ODBEncodingStream initializeTypeCodeMapping
 ]
 
 { #category : #initialization }

--- a/src/OmniBase/ODBnCharacterString.class.st
+++ b/src/OmniBase/ODBnCharacterString.class.st
@@ -22,5 +22,5 @@ ODBnCharacterString >> n: anInteger [
 { #category : #accessing }
 ODBnCharacterString >> odbDeserialize: deserializer [
 
-  ^ deserializer stream nextnCharacterString: deserializer size: n 
+  ^ deserializer stream nextnCharacterString: deserializer size: n
 ]

--- a/src/OmniBase/Object.extension.st
+++ b/src/OmniBase/Object.extension.st
@@ -9,7 +9,6 @@ Object >> asBtreeKeyOfSize: keySize [
 { #category : #'*omnibase' }
 Object >> commit: serializer [
 	"do nothing"
-
 ]
 
 { #category : #'*omnibase' }
@@ -63,7 +62,6 @@ Object >> makePersistent [
 		ifFalse:[OmniBase currentTransaction makePersistent: self in: ARCurrentContainer value]"
 	
 	OmniBase currentTransaction makePersistent: self
-		
 ]
 
 { #category : #'*omnibase' }
@@ -88,8 +86,6 @@ Object >> odbAboutToCommitIn: anOmniBaseTransaction [
 	"Sent before transaction writes changes to the database (right before commit).
 	In this method you can use transaction the same way as usual.
 	Do nothing by default."
-
-	
 ]
 
 { #category : #'*omnibase' }

--- a/src/OmniBase/OmniBase.class.st
+++ b/src/OmniBase/OmniBase.class.st
@@ -214,7 +214,6 @@ OmniBase class >> reset [
 	processToTransactionDict := IdentityDictionary new.
 	processToTransactionMutex := Semaphore forMutualExclusion.
 	currentTransaction := nil.
-	
 ]
 
 { #category : #public }
@@ -312,7 +311,7 @@ OmniBase >> containerNamed: aName [
 OmniBase >> containerNamed: aName ifAbsent: aBlock [
 	"Answers the container the receiver locates at aName or executes aBlock if not found."
 
-	^ objectManager containerNamed: aName ifAbsent: aBlock 
+	^ objectManager containerNamed: aName ifAbsent: aBlock
 ]
 
 { #category : #public }

--- a/src/OmniBase/OrderedCollection.extension.st
+++ b/src/OmniBase/OrderedCollection.extension.st
@@ -3,11 +3,11 @@ Extension { #name : #OrderedCollection }
 { #category : #'*omnibase' }
 OrderedCollection >> odbBasicSerialize: serializer [
 
-	serializer stream nextPutOrderedCollection: self 
+	serializer stream nextPutOrderedCollection: self
 ]
 
 { #category : #'*omnibase' }
 OrderedCollection class >> odbDeserialize: deserializer [
 
-	^ deserializer stream nextOrderedCollection: self 
+	^ deserializer stream nextOrderedCollection: self
 ]

--- a/src/OmniBase/ProcessorScheduler.extension.st
+++ b/src/OmniBase/ProcessorScheduler.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #ProcessorScheduler }
 { #category : #'*omnibase' }
 ProcessorScheduler >> odbBasicSerialize: serializer [
 
-	serializer stream nextPutProcessorScheduler: self 
+	serializer stream nextPutProcessorScheduler: self
 ]
 
 { #category : #'*omnibase' }

--- a/src/OmniBase/SmallFloat64.extension.st
+++ b/src/OmniBase/SmallFloat64.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #SmallFloat64 }
 
 { #category : #'*OmniBase' }
 SmallFloat64 >> odbBasicSerialize: serializer [ 
-	serializer stream nextPutSmallFloat64: self 
+	serializer stream nextPutSmallFloat64: self
 ]
 
 { #category : #'*OmniBase' }

--- a/src/OmniBase/String.extension.st
+++ b/src/OmniBase/String.extension.st
@@ -15,7 +15,7 @@ String >> odbBasicSerialize: serializer [
 { #category : #'*omnibase' }
 String class >> odbDeserialize: deserializer [
 
-	^ deserializer stream nextString: deserializer 
+	^ deserializer stream nextString: deserializer
 ]
 
 { #category : #'*omnibase' }

--- a/src/OmniBase/Symbol.extension.st
+++ b/src/OmniBase/Symbol.extension.st
@@ -9,7 +9,7 @@ Symbol >> odbBasicSerialize: serializer [
 { #category : #'*omnibase' }
 Symbol class >> odbDeserialize: deserializer [
 
-	^ deserializer stream nextSymbol: deserializer 
+	^ deserializer stream nextSymbol: deserializer
 ]
 
 { #category : #'*omnibase' }

--- a/src/OmniBase/SystemDictionary.extension.st
+++ b/src/OmniBase/SystemDictionary.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #SystemDictionary }
 { #category : #'*omnibase' }
 SystemDictionary >> odbBasicSerialize: serializer [
 
-	serializer stream nextPutSystemDictionary: self 
+	serializer stream nextPutSystemDictionary: self
 ]
 
 { #category : #'*omnibase' }

--- a/src/OmniBase/Time.extension.st
+++ b/src/OmniBase/Time.extension.st
@@ -3,11 +3,11 @@ Extension { #name : #Time }
 { #category : #'*omnibase' }
 Time >> odbBasicSerialize: serializer [
 
-	serializer stream nextPutTime: self 
+	serializer stream nextPutTime: self
 ]
 
 { #category : #'*omnibase' }
 Time class >> odbDeserialize: deserializer [
 
-	^ deserializer stream nextTime: deserializer 
+	^ deserializer stream nextTime: deserializer
 ]

--- a/src/OmniBase/True.extension.st
+++ b/src/OmniBase/True.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #True }
 { #category : #'*omnibase' }
 True >> odbBasicSerialize: serializer [
 
-	serializer stream nextPutTrue: self 
+	serializer stream nextPutTrue: self
 ]
 
 { #category : #'*omnibase' }

--- a/src/OmniBase/UndefinedObject.extension.st
+++ b/src/OmniBase/UndefinedObject.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #UndefinedObject }
 { #category : #'*omnibase' }
 UndefinedObject >> odbBasicSerialize: serializer [
 
-	serializer stream nextPutNil: self 
+	serializer stream nextPutNil: self
 ]
 
 { #category : #'*omnibase' }

--- a/src/OmniBase/WideString.extension.st
+++ b/src/OmniBase/WideString.extension.st
@@ -9,5 +9,5 @@ WideString >> odbBasicSerialize: serializer [
 { #category : #'*OmniBase' }
 WideString class >> odbDeserialize: deserializer [
 
-	^ deserializer stream nextWideString: deserializer 
+	^ deserializer stream nextWideString: deserializer
 ]


### PR DESCRIPTION
add #cleanupWhiteSpaceTrimRight that can be used to remove all the emptyness at the end of methods (I think pharo should do that on save but does not yet...)