### PR TITLE
3-ODBVersionDescriptor-redefines--but-does-not-implement-hash

### DIFF
--- a/src/OmniBase/ODBVersionControlFile.class.st
+++ b/src/OmniBase/ODBVersionControlFile.class.st
@@ -58,16 +58,18 @@ ODBVersionControlFile >> versionDescriptor [
 	"Answer read versionDescriptor."
 
 	| versionTable size time |
-	(versionDescriptor isNil 
-		or: [((time := Time millisecondClockValue) - lastReadTime) abs > 500]) 
-			ifTrue: 
-				[size := (ODBClientTable maxClients + 1) * 4.
-				versionTable := ByteArray new: size.
-				stream 
-					atPosition: self headerLength
-					getBytesFor: versionTable
-					len: size.
-				lastReadTime := time isNil ifTrue: [Time millisecondClockValue] ifFalse: [time].
-				versionDescriptor := ODBVersionDescriptor new fromVersionTable: versionTable].
-	^versionDescriptor
+	(versionDescriptor isNil or: [ 
+		 ((time := Time millisecondClockValue) - lastReadTime) abs > 500 ]) 
+		ifTrue: [ 
+			size := ODBClientTable maxClients + 1 * 4.
+			versionTable := ByteArray new: size.
+			stream
+				atPosition: self headerLength
+				getBytesFor: versionTable
+				len: size.
+			lastReadTime := time
+				                ifNil: [ Time millisecondClockValue ]
+				                ifNotNil: [ time ].
+			versionDescriptor := ODBVersionDescriptor new fromVersionTable: versionTable ].
+	^ versionDescriptor
 ]

--- a/src/OmniBase/ODBVersionDescriptor.class.st
+++ b/src/OmniBase/ODBVersionDescriptor.class.st
@@ -11,7 +11,7 @@ Class {
 	#category : #'OmniBase-Model'
 }
 
-{ #category : #public }
+{ #category : #comparing }
 ODBVersionDescriptor >> = anObject [ 
 	anObject class == self class ifFalse: [^false].
 	^topVersionNumber == anObject topVersionNumber 
@@ -24,7 +24,7 @@ ODBVersionDescriptor >> committingTransactions [
         ^committingTransactions
 ]
 
-{ #category : #'public/unclassified' }
+{ #category : #copying }
 ODBVersionDescriptor >> copy [
 
     ^self class new
@@ -49,6 +49,14 @@ ODBVersionDescriptor >> fromVersionTable: aByteArray [
 					[committingTransactions add: vn.
 					vn <= readVersionNumber ifTrue: [readVersionNumber := vn - 1]].
 			i := i + 4]
+]
+
+{ #category : #comparing }
+ODBVersionDescriptor >> hash [
+
+	^ (self class hash
+		bitXor: self topVersionNumber hash)
+		bitXor: self committingTransactions hash
 ]
 
 { #category : #'private/unclassified' }


### PR DESCRIPTION
Implement #hash to be in sync with #= , fixes #3