### PR TITLE
nextString is not needed as we use #nextString:

### DIFF
--- a/src/OmniBase/ODBEncodingStream.class.st
+++ b/src/OmniBase/ODBEncodingStream.class.st
@@ -568,14 +568,6 @@ ODBEncodingStream >> nextSmallFloat64: aDeserializer [
 ]
 
 { #category : #actions }
-ODBEncodingStream >> nextString [
-	| buf len |
-	buf := ByteArray new: (len := stream getPositiveInteger).
-	stream getBytesFor: buf len: len.
-	^  buf asString
-]
-
-{ #category : #actions }
 ODBEncodingStream >> nextString: aDeserializer [
 	| buf len string |
 	buf := ByteArray new: (len := stream getPositiveInteger).


### PR DESCRIPTION
... we can delete it