### PR TITLE
Remove SmalltalkImage #odbSeserialize:

### DIFF
--- a/src/OmniBase/SmalltalkImage.extension.st
+++ b/src/OmniBase/SmalltalkImage.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #SmalltalkImage }
-
-{ #category : #'*OmniBase' }
-SmalltalkImage >> odbDeserialize: deserializer [
-
-	^ globals
-]


### PR DESCRIPTION
"Smalltalk globals" is special encoded, but not SmalltalkImage.

(and de-serializing  Smalltalk to "Smalltalk globals" would be wrong)