### PR TITLE
clean up ODBFileStreamWrapper>>#basicGetBytesFor:len:

### DIFF
--- a/src/OmniBase/ODBFileStreamWrapper.class.st
+++ b/src/OmniBase/ODBFileStreamWrapper.class.st
@@ -9,12 +9,14 @@ Class {
 
 { #category : #accessing }
 ODBFileStreamWrapper >> atPosition: anInteger getBytesFor: aByteCollection [
+
 	"Read bytes from stream at position anInteger. 
     Answer number of bytes actualy read."
 
 	^ mutex critical: [ 
-		  stream position: anInteger.
-		  self basicGetBytesFor: aByteCollection len: aByteCollection size ]
+		stream position: anInteger.
+		self flush.
+		super getBytesFor: aByteCollection len: aByteCollection size ]
 ]
 
 { #category : #accessing }
@@ -24,7 +26,8 @@ ODBFileStreamWrapper >> atPosition: anInteger getBytesFor: aByteCollection len: 
 
 	^ mutex critical: [ 
 		stream position: anInteger.
-		self basicGetBytesFor: aByteCollection len: len ]
+		self flush.
+		super getBytesFor: aByteCollection len: len ]
 ]
 
 { #category : #accessing }
@@ -68,16 +71,6 @@ ODBFileStreamWrapper >> atPositionGetLong: pos [
 		getBytesFor: buf
 		len: 4) == 4 
 		ifTrue: [buf odbLongAt: 1]
-]
-
-{ #category : #accessing }
-ODBFileStreamWrapper >> basicGetBytesFor: aByteCollection len: len [
-		"Read len bytes from stream to aByteCollection. 
-		Answer number of bytes actualy read."
-
-	^ stream 
-		flush; 
-		readInto: aByteCollection startingAt: 1 count: len
 ]
 
 { #category : #accessing }
@@ -137,11 +130,13 @@ ODBFileStreamWrapper >> getByte [
 ]
 
 { #category : #public }
-ODBFileStreamWrapper >> getBytesFor: aByteCollection len: len [ 
+ODBFileStreamWrapper >> getBytesFor: aByteCollection len: len [
 	"Read len bytes from stream to aByteCollection. 
 	Answer number of bytes actualy read."
 
-	^ mutex critical: [self basicGetBytesFor: aByteCollection len: len]
+	^ mutex critical: [
+		self flush.
+		super getBytesFor: aByteCollection len: len]
 ]
 
 { #category : #public }

--- a/src/OmniBase/ODBMemoryStreamWrapper.class.st
+++ b/src/OmniBase/ODBMemoryStreamWrapper.class.st
@@ -25,13 +25,6 @@ ODBMemoryStreamWrapper >> getByte [
 ]
 
 { #category : #public }
-ODBMemoryStreamWrapper >> getBytesFor: aByteCollection len: len [ 
-	"Read len bytes from stream to aByteCollection. Answer number of bytes actualy read."
-
-	^ stream readInto: aByteCollection startingAt: 1 count: len
-]
-
-{ #category : #public }
 ODBMemoryStreamWrapper >> getChar [
 
     ^ Character value: self getByte

--- a/src/OmniBase/ODBPrimitiveEncodingStream.class.st
+++ b/src/OmniBase/ODBPrimitiveEncodingStream.class.st
@@ -47,8 +47,10 @@ ODBPrimitiveEncodingStream >> getBytesFor: aByteCollection [
 ]
 
 { #category : #public }
-ODBPrimitiveEncodingStream >> getBytesFor: bytes len: size [
-	self subclassResponsibility
+ODBPrimitiveEncodingStream >> getBytesFor: aByteCollection len: len [ 
+	"Read len bytes from stream to aByteCollection. Answer number of bytes actualy read."
+
+	^ stream readInto: aByteCollection startingAt: 1 count: len
 ]
 
 { #category : #public }


### PR DESCRIPTION
- add #getBytesFor:len: in the superclass
- override it from ODBFileStreamWrapper to add the monitor
- ODBMemoryStreamWrapper now does not need to implement it anymore

An odd thing is the additional #flush on read... we should I think remove it later after making sure we flush after *write*.