### PR TITLE
Tests: Closure and Process

### DIFF
--- a/src/OmniBase-Tests/ODBSerializationTest.class.st
+++ b/src/OmniBase-Tests/ODBSerializationTest.class.st
@@ -39,6 +39,16 @@ ODBSerializationTest >> testSerializationAssociation [
 ]
 
 { #category : #tests }
+ODBSerializationTest >> testSerializationBlockClosure [
+	| object serialized materialized |
+	object := [].
+	serialized := ODBSerializer serializeToBytes: object.
+	
+	materialized := ODBDeserializer deserializeFromBytes: serialized.
+	self assert: materialized equals: #'FullBlockClosure can''t be stored!'
+]
+
+{ #category : #tests }
 ODBSerializationTest >> testSerializationBoolean [
 	| object serialized materialized |
 	object := true.
@@ -385,6 +395,16 @@ ODBSerializationTest >> testSerializationOrderedCollection [
 
 	materialized := ODBDeserializer deserializeFromBytes: serialized.
 	self assert: materialized equals: object
+]
+
+{ #category : #tests }
+ODBSerializationTest >> testSerializationProcess [
+	| object serialized materialized |
+	object := Processor activeProcess.
+	serialized := ODBSerializer serializeToBytes: object.
+	
+	materialized := ODBDeserializer deserializeFromBytes: serialized.
+	self assert: materialized equals: #'Process can''t be stored!'
 ]
 
 { #category : #tests }


### PR DESCRIPTION
add test for closure and Process, the two objects we store an error string instead of the objects