### PR TITLE
Rehash HashedCollections on de-serialization

### DIFF
--- a/src/OmniBase-Tests/ODBDatabaseTest.class.st
+++ b/src/OmniBase-Tests/ODBDatabaseTest.class.st
@@ -329,3 +329,30 @@ ODBDatabaseTest >> testPersistTwoObjectsWithODBDictionary [
 	self assert: txn changesPackage changes size equals: 3.
 	txn abort.
 ]
+
+{ #category : #tests }
+ODBDatabaseTest >> testSetInclusion [
+
+	| obj1 obj2 fromDb1 fromDb2 |
+	[ 
+	obj1 := Set new.
+	obj1 makePersistent.
+	obj2 := ODBTestClass1 new.
+	obj2 makePersistent.
+	obj1 add: obj2.
+
+	OmniBase root at: 'one' put: obj1.
+	OmniBase root at: 'two' put: obj2 ] evaluateAndCommitIn:
+		db newTransaction.
+
+	self assert: (obj1 includes: obj2).
+
+	[ 
+	fromDb1 := OmniBase root at: 'one'.
+	fromDb2 := OmniBase root at: 'two'.
+	"check that we can find the element, we rehash to make sure the
+	Set is in sync with the identity of the contained objects"
+	self assert: (fromDb1 anyOne isIdenticalTo: fromDb2).
+	self assert: (fromDb1 includes: fromDb2 odbResolve) ] evaluateIn:
+		db newReadOnlyTransaction
+]

--- a/src/OmniBase-Tests/ODBSerializationTest.class.st
+++ b/src/OmniBase-Tests/ODBSerializationTest.class.st
@@ -399,6 +399,23 @@ ODBSerializationTest >> testSerializationProcessSchedulerCode [
 	self assert: materialized equals: Processor
 ]
 
+{ #category : #'tests-hashed' }
+ODBSerializationTest >> testSerializationSet [
+	"Set uses the hash to find elements, this might be identity, which changes"
+
+	| set object2 serialized materialized |
+
+	set := Set new.
+	object2 := ODBTestClass1 new.
+	set add: object2.
+
+	serialized := ODBSerializer serializeToBytes: set.
+
+	materialized := ODBDeserializer deserializeFromBytes: serialized.
+	self deny: materialized anyOne identicalTo: set.
+	self assert: (materialized includes:  materialized anyOne)
+]
+
 { #category : #tests }
 ODBSerializationTest >> testSerializationSmallFloat64 [
 	| float serialized materialized |

--- a/src/OmniBase/HashedCollection.extension.st
+++ b/src/OmniBase/HashedCollection.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #HashedCollection }
+
+{ #category : #'*OmniBase' }
+HashedCollection >> odbDeserialized: deserializer [
+	super odbDeserialized: deserializer.
+	"We have to re-hash, as the elements are newly de-serialized objects.
+	If the #hash is using #identityHash, we might not find it anymore"
+	^self rehash 
+]


### PR DESCRIPTION
When we store a Set, it stores all the elements. But on re-load, we create new objects for both the set and the contained objects.

If the contained objects use #identityHash, we now have a Set that was created with different hashes. We, therefore, have to re-hash on load (or alternatively create a new Set, as we do with Dictionary).

This fixes the  problem for all subclasses of HashedCollection.