### PR TITLE
 133-ODBNilCode-is-not-used-there-is-ODBUndefinedObjectCode-to-store-nil 

### DIFF
--- a/src/OmniBase/ODBEncodingStream.class.st
+++ b/src/OmniBase/ODBEncodingStream.class.st
@@ -57,7 +57,6 @@ ODBEncodingStream class >> initializeTypeCodeMapping [
 		at: ODBInternalReference                 put: ODBExistingObject;
 		at: ODBExternalReferenceCode             put: ODBExternalReference;
 		at: 6                                    put: ODBClassManagerForSerialization;
-		at: ODBNilCode                           put: nil;
 		at: ODBLargePositiveIntegerCode          put: ODBLargePositiveInteger;
 		at: ODBLargeNegativeIntegerCode          put: ODBLargeNegativeInteger;
 		at: ODBCharacterCode                     put: Character;

--- a/src/OmniBase/ODBTypeCodes.class.st
+++ b/src/OmniBase/ODBTypeCodes.class.st
@@ -61,7 +61,6 @@ ODBTypeCodes class >> initializeTypeCodes [
 	ODBInternalReference := 4.
 	ODBExternalReferenceCode := 5.
 	"6 .. 10"
-	ODBNilCode := 10.
 	ODBLargePositiveIntegerCode := 11.
 	ODBLargeNegativeIntegerCode := 12.
 	ODBCharacterCode := 13.


### PR DESCRIPTION
remove ODBNilCode, fixes #133