### PR TITLE
anothe small cleanup around senders of #critical:

### DIFF
--- a/src/OmniBase/ODBBTreeIterator.class.st
+++ b/src/OmniBase/ODBBTreeIterator.class.st
@@ -182,13 +182,12 @@ ODBBTreeIterator >> goTo: aByteArray put: aValue [
 ]
 
 { #category : #public }
-ODBBTreeIterator >> goToAndGetCurrentAt: aKey [ 
-	| result |
-	mutex critical: 
-			[result := self
-						goTo: aKey;
-						getCurrent].
-	^result
+ODBBTreeIterator >> goToAndGetCurrentAt: aKey [
+
+	^ mutex critical: [ 
+		  self
+			  goTo: aKey;
+			  getCurrent ]
 ]
 
 { #category : #initialization }

--- a/src/OmniBase/ODBClassManager.class.st
+++ b/src/OmniBase/ODBClassManager.class.st
@@ -99,8 +99,8 @@ ODBClassManager >> classDescriptionAt: anInteger [
 
 	"Answers class at class id anInteger."
 
-	| pos classInfo stream |
-	mutex critical: [ 
+	^ mutex critical: [ 
+		| pos classInfo stream |
 		classes size < anInteger ifFalse: [ 
 			(classInfo := classes at: anInteger) ifNotNil: [ ^ classInfo ] ].
 		(pos := idTable at: anInteger) ifNil: [ 
@@ -110,8 +110,8 @@ ODBClassManager >> classDescriptionAt: anInteger [
 		stream position: pos + 4.
 		classInfo := self classDescriptionFrom: stream.
 		classInfo classID: anInteger.
-		self addClassInfo: classInfo ].
-	^ classInfo
+		self addClassInfo: classInfo.
+		classInfo ]
 ]
 
 { #category : #public }
@@ -211,15 +211,15 @@ ODBClassManager >> register: aClass [
 	"Answer an instance of ODBClassDescription for aClass.
 	ODBClassDescription holds meta information about objects in the database."
 
-	| info pos |
-	mutex critical: [ 
+	^mutex critical: [ 
+		| info pos |
 		(info := self find: aClass) ifNotNil: [ ^ info ].
 		pos := infoFile
 			       at: aClass name
 			       ifAbsent: [ ^ self registerNewClass: aClass ].
 		pos := self loadInfoChainFrom: pos.
 		(info := self find: aClass) ifNotNil: [ ^ info ].
-		^ self registerNewClassVersion: aClass from: pos ]
+		self registerNewClassVersion: aClass from: pos ]
 ]
 
 { #category : #private }

--- a/src/OmniBase/ODBContainer.class.st
+++ b/src/OmniBase/ODBContainer.class.st
@@ -56,16 +56,15 @@ ODBContainer >> close [
 ]
 
 { #category : #public }
-ODBContainer >> closeObjectFile: anInteger [ 
-	"Remove database object file number anInteger from 
-        dictionary of opened files and close it."
+ODBContainer >> closeObjectFile: anInteger [
 
-	| file |
-	dbFilesMutex critical: 
-			[file := dbFiles at: anInteger ifAbsent: [^self].
-			dbFiles removeKey: anInteger.
-			file
-				close]
+	"Remove database object file number anInteger from dictionary of opened files and close it."
+
+	dbFilesMutex critical: [ 
+		| file |
+		file := dbFiles at: anInteger ifAbsent: [ ^ self ].
+		dbFiles removeKey: anInteger.
+		file close ]
 ]
 
 { #category : #public }
@@ -298,15 +297,15 @@ ODBContainer >> objectManager: anODBObjectManager [
 ]
 
 { #category : #public }
-ODBContainer >> onNewObjectFileDo: aBlock [ 
-	| file newIndex |
-	dbFilesMutex critical: 
-			[newIndex := indexFile newObjectFileID.
-			file := aBlock value: newIndex value: (self fileNameFromIndex: newIndex).
-			file notNil 
-				ifTrue: 
-					[dbFiles at: newIndex put: file]].
-	^file
+ODBContainer >> onNewObjectFileDo: aBlock [
+
+	^ dbFilesMutex critical: [ 
+		  | file newIndex |
+		  newIndex := indexFile newObjectFileID.
+		  file := aBlock
+			          value: newIndex
+			          value: (self fileNameFromIndex: newIndex).
+		  ^file ifNotNil: [ dbFiles at: newIndex put: file. file] ]
 ]
 
 { #category : #public }
@@ -349,9 +348,9 @@ ODBContainer >> removeHolderAt: index [
 
 { #category : #private }
 ODBContainer >> removeObjectFile: anInteger [ 
-	| file |
 	dbFilesMutex critical: 
-			[file := dbFiles at: anInteger ifAbsent: [^self].
+			[| file |
+			file := dbFiles at: anInteger ifAbsent: [^self].
 			dbFiles removeKey: anInteger.
 			file ifNotNil:[
 				file close].

--- a/src/OmniBase/ODBDBBTreeDictionary.class.st
+++ b/src/OmniBase/ODBDBBTreeDictionary.class.st
@@ -44,11 +44,10 @@ ODBDBBTreeDictionary >> referencesDo: aBlock [
 ]
 
 { #category : #public }
-ODBDBBTreeDictionary >> unlockKey: aKey with: lockID [ 
-	| result |
-	iterator critical: 
-			[result := iterator
-						goTo: aKey;
-						unlockCurrentWith: lockID].
-	^result
+ODBDBBTreeDictionary >> unlockKey: aKey with: lockID [
+
+	^ iterator critical: [ 
+		  iterator
+			  goTo: aKey;
+			  unlockCurrentWith: lockID ]
 ]

--- a/src/OmniBase/ODBLocalTransaction.class.st
+++ b/src/OmniBase/ODBLocalTransaction.class.st
@@ -308,10 +308,12 @@ ODBLocalTransaction >> printOn: aStream [
 ]
 
 { #category : #private }
-ODBLocalTransaction >> removeCachedObjectID: objectID [ 
+ODBLocalTransaction >> removeCachedObjectID: objectID [
+
 	"Remove transaction object associated with objectID."
 
-	objects isNil ifFalse: [cacheMutex critical: [objects removeKey: objectID]]
+	objects ifNotNil: [ 
+		cacheMutex critical: [ objects removeKey: objectID ] ]
 ]
 
 { #category : #private }

--- a/src/OmniBase/ODBLockRegistry.class.st
+++ b/src/OmniBase/ODBLockRegistry.class.st
@@ -150,7 +150,7 @@ ODBLockRegistry >> removeLock: anODBObjectLock [
 	mutex critical: [
 		locks 
 			removeKey: anODBObjectLock lockRegistryKey 
-			ifAbsent: [  ] ].
+			ifAbsent: nil ].
 	self checkRemoval
 ]
 

--- a/src/OmniBase/ODBTransaction.class.st
+++ b/src/OmniBase/ODBTransaction.class.st
@@ -78,9 +78,7 @@ ODBTransaction >> cachedObjectAt: objectID [
 ODBTransaction >> cachedTransactionObjectAt: objectID [ 
 	"Private - Answer cached transaction object at objectID."
 
-	| obj |
-	cacheMutex critical: [obj := objects at: objectID].
-	^obj
+	^cacheMutex critical: [objects at: objectID].
 ]
 
 { #category : #'public/accessing' }

--- a/src/OmniBase/ODBTransactionManager.class.st
+++ b/src/OmniBase/ODBTransactionManager.class.st
@@ -39,7 +39,7 @@ ODBTransactionManager >> createOn: aDatabase [
 { #category : #'public/accessing' }
 ODBTransactionManager >> critical: aBlock [
 
-	mutex critical: aBlock
+	^mutex critical: aBlock
 ]
 
 { #category : #public }

--- a/src/OmniBase/OmniBase.class.st
+++ b/src/OmniBase/OmniBase.class.st
@@ -117,11 +117,12 @@ OmniBase class >> getCurrentAndSet: anOmniBaseTransaction for: aProcess [
 	"Private - Associaties anOmniBaseTransaction with aProcess.
 	Answer previous active transaction in case transactions are nested."
 
-	| previousTxn |
-	processToTransactionMutex critical: 
-			[previousTxn := processToTransactionDict at: aProcess ifAbsent: nil.
-			processToTransactionDict at: aProcess put: anOmniBaseTransaction].
-	^previousTxn
+
+	^ processToTransactionMutex critical: 
+			[| previousTxn |
+			previousTxn := processToTransactionDict at: aProcess ifAbsent: nil.
+			processToTransactionDict at: aProcess put: anOmniBaseTransaction.
+			previousTxn]
 ]
 
 { #category : #'class initialization' }
@@ -204,7 +205,7 @@ OmniBase class >> removeFor: aProcess [
 	"Private - Disassociaties a transaction from aProcess."
 
 	processToTransactionMutex 
-		critical: [processToTransactionDict removeKey: aProcess ifAbsent: []]
+		critical: [processToTransactionDict removeKey: aProcess ifAbsent: nil]
 ]
 
 { #category : #'class initialization' }


### PR DESCRIPTION
- it returns the block value, no need for temps
- move temp definiton into the critical block (avoids escaping var access)
- use nil instead of []
- some ifNil: transforms