### PR TITLE
165-Cleanup-ODBEncodingStreaminitializeTypeCodeMapping-is-not-used 

### DIFF
--- a/src/OmniBase/ODBEncodingStream.class.st
+++ b/src/OmniBase/ODBEncodingStream.class.st
@@ -156,6 +156,18 @@ ODBEncodingStream >> nextDoubleByteCharacter [
 ]
 
 { #category : #reading }
+ODBEncodingStream >> nextFloatAs100Integer [
+
+    ^ stream getInteger / 100.0
+]
+
+{ #category : #reading }
+ODBEncodingStream >> nextFloatAsInteger [
+
+    ^ stream getInteger asFloat
+]
+
+{ #category : #reading }
 ODBEncodingStream >> nextFraction: aClass [
 	^ aClass 
 		numerator: stream getInteger
@@ -220,7 +232,7 @@ ODBEncodingStream >> nextOrderedCollection: aClass [
 
 { #category : #reading }
 ODBEncodingStream >> nextPersistentDictionary: aClass [
-	| size dict |
+		| size dict |
 	size := stream getPositiveInteger.
 	dict := aClass new: size.
 	readerWriter register: dict.
@@ -500,7 +512,7 @@ ODBEncodingStream >> nextWideString [
 
 { #category : #reading }
 ODBEncodingStream >> nextnCharacterStringSize: size [
-	| buf |
+	    | buf |
    stream getBytesFor: (buf := ByteArray new: size) len: size.
     ^ readerWriter register: buf asString
 ]

--- a/src/OmniBase/ODBEncodingStream.class.st
+++ b/src/OmniBase/ODBEncodingStream.class.st
@@ -46,80 +46,6 @@ ODBEncodingStream class >> initializeEncoding [
 	self characterEncoding: #utf8
 ]
 
-{ #category : #initialization }
-ODBEncodingStream class >> initializeTypeCodeMapping [
-	<script>
-
-	typeCodeMapping := Array new: 255.
-	typeCodeMapping
-		at: 2                                    put: ODBNewObjectNewClass;
-		at: 3                                    put: ODBNewObject;
-		at: ODBInternalReference                 put: ODBExistingObject;
-		at: ODBExternalReferenceCode             put: ODBExternalReference;
-		at: 6                                    put: ODBClassManagerForSerialization;
-		at: ODBLargePositiveIntegerCode          put: ODBLargePositiveInteger;
-		at: ODBLargeNegativeIntegerCode          put: ODBLargeNegativeInteger;
-		at: ODBCharacterCode                     put: Character;
-		at: ODBUndefinedObjectCode               put: UndefinedObject;
-		at: ODBTrueCode                          put: true;
-		at: ODBFalseCode                         put: false;
-		at: ODBMessageCode                       put: Message;
-		at: ODBSymbolCode                        put: Symbol;
-		at: ODBSystemDictionaryCode              put: Smalltalk globals;
-		at: ODBMessageSendCode                   put: MessageSend;
-		at: ODBProcessSchedulerCode              put: Processor;
-		at: ODBClassCode                         put: Class;
-		at: ODBDoubleByteCharacterCode           put: ODBDoubleByteCharacter;
-		at: ODBAssociationCode                   put: Association;
-		at: ODBDateCode                          put: Date;
-		at: ODBTimeCode                          put: Time;
-		at: ODBStringCode                        put: String;
-		at: ODBArrayCode                         put: Array;
-		at: ODBWideStringCode                    put: WideString;
-		at: ODBDictionaryCode                    put: Dictionary;
-		at: ODBIdentityDictionaryCode            put: IdentityDictionary;
-		at: ODBFractionCode                      put: Fraction;
-		at: ODBFloatCode                         put: Float;
-		at: ODBScaledDecimalCode                 put: ScaledDecimal;
-		at: ODBSmallFloat64Code                  put: SmallFloat64;
-	
-		at: ODBSmallPositiveIntegerBaseCode      put: 0;
-		at: ODBSmallPositiveIntegerBaseCode + 1  put: 1;
-		at: ODBSmallPositiveIntegerBaseCode + 2  put: 2;
-		at: ODBSmallPositiveIntegerBaseCode + 3  put: 3;
-		at: ODBSmallPositiveIntegerBaseCode + 4  put: 4;
-		at: ODBSmallPositiveIntegerBaseCode + 5  put: 5;
-		at: ODBSmallPositiveIntegerBaseCode + 6  put: 6;
-		at: ODBSmallPositiveIntegerBaseCode + 7  put: 7;
-		at: ODBSmallPositiveIntegerBaseCode + 8  put: 8;
-		at: ODBSmallPositiveIntegerBaseCode + 9  put: 9;
-		at: ODBSmallPositiveIntegerBaseCode + 10 put: 10;
-		at: ODBSmallPositiveIntegerBaseCode + 11 put: 11;
-		at: ODBSmallPositiveIntegerBaseCode + 12 put: 12;
-		at: ODBSmallPositiveIntegerBaseCode + 13 put: 13;
-		at: ODBSmallPositiveIntegerBaseCode + 14 put: 14;
-		at: ODBSmallPositiveIntegerBaseCode + 15 put: 15;
-		at: ODBSmallPositiveIntegerBaseCode + 16 put: 16;
-		at: ODBMinusThreeCode                    put: -3;
-		at: ODBMinusTwo                          put: -2;
-		at: ODBMinusOne                          put: -1;
-		at: ODBSmallStringBaseCode               put: ODBEmptyString;
-		at: ODBSmallStringBaseCode + 1           put: ODB1CharacterString;
-		at: ODBSmallStringBaseCode + 2           put: (ODBnCharacterString length: 2);
-		at: ODBSmallStringBaseCode + 3           put: (ODBnCharacterString length: 3);
-		at: ODBSmallStringBaseCode + 4           put: (ODBnCharacterString length: 4);
-		at: ODBSmallStringBaseCode + 5           put: (ODBnCharacterString length: 5);
-		at: ODBSmallStringBaseCode + 6           put: (ODBnCharacterString length: 6);
-		at: ODBSmallStringBaseCode + 7           put: (ODBnCharacterString length: 7);
-		at: ODBSmallStringBaseCode + 8           put: (ODBnCharacterString length: 8);
-		at: ODBSmallStringBaseCode + 9           put: (ODBnCharacterString length: 9);
-		at: ODBByteArrayCode                     put: ByteArray;
-		at: ODBOrderedCollectionCode             put: OrderedCollection;
-		at: ODBODBIdentityDictionaryCode         put: ODBIdentityDictionary; 
-		at: ODBPersistentDictionaryCode          put: ODBPersistentDictionary;
-		at: ODBTransactionCode                   put: ODBTransaction.
-]
-
 { #category : #'instance creation' }
 ODBEncodingStream class >> on: aStream [ 
 	^ self new 
@@ -230,18 +156,6 @@ ODBEncodingStream >> nextDoubleByteCharacter [
 ]
 
 { #category : #reading }
-ODBEncodingStream >> nextFloatAs100Integer [
-
-    ^ stream getInteger / 100.0
-]
-
-{ #category : #reading }
-ODBEncodingStream >> nextFloatAsInteger [
-
-    ^ stream getInteger asFloat
-]
-
-{ #category : #reading }
 ODBEncodingStream >> nextFraction: aClass [
 	^ aClass 
 		numerator: stream getInteger
@@ -306,7 +220,7 @@ ODBEncodingStream >> nextOrderedCollection: aClass [
 
 { #category : #reading }
 ODBEncodingStream >> nextPersistentDictionary: aClass [
-		| size dict |
+	| size dict |
 	size := stream getPositiveInteger.
 	dict := aClass new: size.
 	readerWriter register: dict.
@@ -586,7 +500,7 @@ ODBEncodingStream >> nextWideString [
 
 { #category : #reading }
 ODBEncodingStream >> nextnCharacterStringSize: size [
-	    | buf |
+	| buf |
    stream getBytesFor: (buf := ByteArray new: size) len: size.
     ^ readerWriter register: buf asString
 ]

--- a/src/OmniBase/ODBTypeCodes.class.st
+++ b/src/OmniBase/ODBTypeCodes.class.st
@@ -45,8 +45,7 @@ Class {
 
 { #category : #initialization }
 ODBTypeCodes class >> initialize [ 
-	self initializeTypeCodes.
-	ODBEncodingStream initializeTypeCodeMapping
+	self initializeTypeCodes
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
- remove initializeTypeCodeMapping
- remove #nextFloatAsInteger and #nextFloatAs100Integer

fixes #165