### PR TITLE
Cleanup-Streams-getChar-getByte

### DIFF
--- a/src/OmniBase/ODBFileStreamWrapper.class.st
+++ b/src/OmniBase/ODBFileStreamWrapper.class.st
@@ -126,7 +126,7 @@ ODBFileStreamWrapper >> getByte [
 
 	| buf |
 	buf := ByteArray new: 1.
-	^(self getBytesFor: buf len: 1) == 1 ifTrue: [buf at: 1]
+	^(self getBytesFor: buf len: 1) == 1 ifTrue: [buf at: 1] ifFalse: [ nil ]
 ]
 
 { #category : #public }

--- a/src/OmniBase/ODBMemoryStreamWrapper.class.st
+++ b/src/OmniBase/ODBMemoryStreamWrapper.class.st
@@ -20,17 +20,6 @@ ODBMemoryStreamWrapper >> createOn: aByteArray [
 ]
 
 { #category : #public }
-ODBMemoryStreamWrapper >> getByte [
-	^ stream next
-]
-
-{ #category : #public }
-ODBMemoryStreamWrapper >> getChar [
-
-    ^ Character value: self getByte
-]
-
-{ #category : #public }
 ODBMemoryStreamWrapper >> getLong [
 
     ^self getWord bitOr: (self getWord bitShift: 16)

--- a/src/OmniBase/ODBPrimitiveEncodingStream.class.st
+++ b/src/OmniBase/ODBPrimitiveEncodingStream.class.st
@@ -37,7 +37,7 @@ ODBPrimitiveEncodingStream >> getBoolean [
 
 { #category : #public }
 ODBPrimitiveEncodingStream >> getByte [
-	self subclassResponsibility
+	^ stream next
 ]
 
 { #category : #public }
@@ -56,7 +56,7 @@ ODBPrimitiveEncodingStream >> getBytesFor: aByteCollection len: len [
 { #category : #public }
 ODBPrimitiveEncodingStream >> getChar [
 
-    ^ Character value: stream getByte
+    ^ Character value: self getByte
 ]
 
 { #category : #public }


### PR DESCRIPTION
- do not implement getByte and getChar in ODBMemoryStreamWrapper
- instead implement them in ODBPrimitiveEncodingStream
- return nil explicity in ODBFileStreamWrapper>>#getByte to fix CodeCritique complaint