### PR TITLE
Unify names of class vars in ODBTypeCodes

### DIFF
--- a/src/OmniBase-Tests/ODBSerializationTest.class.st
+++ b/src/OmniBase-Tests/ODBSerializationTest.class.st
@@ -674,7 +674,7 @@ ODBSerializationTest >> testSerializationStringTwice [
 	"First String"
 	self assert: (serialized at: 9) equals: ODBSmallStringBaseCode + 1.
 	"Second String is stored as an internal reference"
-	self assert: (serialized at: 11) equals: ODBInternalReference.
+	self assert: (serialized at: 11) equals: ODBInternalReferenceCode.
 	
 	materialized := ODBDeserializer deserializeFromBytes: serialized.
 	self assert: materialized equals: object.
@@ -689,7 +689,7 @@ ODBSerializationTest >> testSerializationStringTwice [
 	"First String"
 	self assert: (serialized at: 9) equals: ODBSmallStringBaseCode + 5.
 	"Second String is stored as an internal reference"
-	self assert: (serialized at: 15) equals: ODBInternalReference.
+	self assert: (serialized at: 15) equals: ODBInternalReferenceCode.
 	
 
 	
@@ -706,7 +706,7 @@ ODBSerializationTest >> testSerializationStringTwice [
 	"First String"
 	self assert: (serialized at: 9) equals: ODBStringCode.
 	"Second String is stored as an internal reference"
-	self assert: (serialized at: 34) equals: ODBInternalReference.
+	self assert: (serialized at: 34) equals: ODBInternalReferenceCode.
 	
 	materialized := ODBDeserializer deserializeFromBytes: serialized.
 	self assert: materialized equals: object.

--- a/src/OmniBase-Tests/ODBSerializationTest.class.st
+++ b/src/OmniBase-Tests/ODBSerializationTest.class.st
@@ -594,8 +594,8 @@ ODBSerializationTest >> testSerializationSmallInteger [
 	materialized := ODBDeserializer deserializeFromBytes: serialized.
 	self assert: materialized equals: -3.
 	
-	self assert: ((ODBSerializer serializeToBytes: -1) at: 7) equals: ODBMinusOne.
-		self assert: ((ODBSerializer serializeToBytes: -2) at: 7) equals: ODBMinusTwo.
+	self assert: ((ODBSerializer serializeToBytes: -1) at: 7) equals: ODBMinusOneCode.
+	self assert: ((ODBSerializer serializeToBytes: -2) at: 7) equals: ODBMinusTwoCode.
 ]
 
 { #category : #'tests-encoded-subclasses' }

--- a/src/OmniBase/ODBEncodingStream.class.st
+++ b/src/OmniBase/ODBEncodingStream.class.st
@@ -506,7 +506,7 @@ ODBEncodingStream >> nextnCharacterStringSize: size [
 
 { #category : #reading }
 ODBEncodingStream >> odbNextObject [
-	^ (typeCodeMapping at: stream getByte) odbDeserialize: readerWriter 
+	^ (TypeCodeMapping at: stream getByte) odbDeserialize: readerWriter 
 ]
 
 { #category : #accessing }

--- a/src/OmniBase/ODBEncodingStream.class.st
+++ b/src/OmniBase/ODBEncodingStream.class.st
@@ -349,7 +349,7 @@ ODBEncodingStream >> nextPutInteger: anInteger [
 { #category : #writing }
 ODBEncodingStream >> nextPutInternalReference: anInteger [ 
 	stream
-		putByte: ODBInternalReference;
+		putByte: ODBInternalReferenceCode;
 		putPositiveInteger: anInteger
 ]
 

--- a/src/OmniBase/ODBTypeCodes.class.st
+++ b/src/OmniBase/ODBTypeCodes.class.st
@@ -15,7 +15,7 @@ Class {
 		'ODBFloatCode',
 		'ODBFractionCode',
 		'ODBIdentityDictionaryCode',
-		'ODBInternalReference',
+		'ODBInternalReferenceCode',
 		'ODBLargeNegativeIntegerCode',
 		'ODBLargePositiveIntegerCode',
 		'ODBMessageCode',
@@ -58,7 +58,7 @@ ODBTypeCodes class >> initializeTypeCodeMapping [
 	TypeCodeMapping
 		at: 2                                    put: ODBNewObjectNewClass;
 		at: 3                                    put: ODBNewObject;
-		at: ODBInternalReference                 put: ODBExistingObject;
+		at: ODBInternalReferenceCode             put: ODBExistingObject;
 		at: ODBExternalReferenceCode             put: ODBExternalReference;
 		at: 6                                    put: ODBClassManagerForSerialization;
 		at: ODBLargePositiveIntegerCode          put: ODBLargePositiveInteger;
@@ -128,7 +128,7 @@ ODBTypeCodes class >> initializeTypeCodeMapping [
 ODBTypeCodes class >> initializeTypeCodes [
 	<script>
 	"1 .. 3" 
-	ODBInternalReference := 4.
+	ODBInternalReferenceCode := 4.
 	ODBExternalReferenceCode := 5.
 	"6 .. 10"
 	ODBLargePositiveIntegerCode := 11.

--- a/src/OmniBase/ODBTypeCodes.class.st
+++ b/src/OmniBase/ODBTypeCodes.class.st
@@ -20,9 +20,9 @@ Class {
 		'ODBLargePositiveIntegerCode',
 		'ODBMessageCode',
 		'ODBMessageSendCode',
-		'ODBMinusOne',
+		'ODBMinusOneCode',
 		'ODBMinusThreeCode',
-		'ODBMinusTwo',
+		'ODBMinusTwoCode',
 		'ODBODBIdentityDictionaryCode',
 		'ODBOrderedCollectionCode',
 		'ODBPersistentDictionaryCode',
@@ -39,7 +39,7 @@ Class {
 		'ODBTrueCode',
 		'ODBUndefinedObjectCode',
 		'ODBWideStringCode',
-		'typeCodeMapping'
+		'TypeCodeMapping'
 	],
 	#category : #'OmniBase-Base'
 }
@@ -54,8 +54,8 @@ ODBTypeCodes class >> initialize [
 ODBTypeCodes class >> initializeTypeCodeMapping [
 	<script>
 
-	typeCodeMapping := Array new: 255.
-	typeCodeMapping
+	TypeCodeMapping := Array new: 255.
+	TypeCodeMapping
 		at: 2                                    put: ODBNewObjectNewClass;
 		at: 3                                    put: ODBNewObject;
 		at: ODBInternalReference                 put: ODBExistingObject;
@@ -105,8 +105,8 @@ ODBTypeCodes class >> initializeTypeCodeMapping [
 		at: ODBSmallPositiveIntegerBaseCode + 15 put: 15;
 		at: ODBSmallPositiveIntegerBaseCode + 16 put: 16;
 		at: ODBMinusThreeCode                    put: -3;
-		at: ODBMinusTwo                          put: -2;
-		at: ODBMinusOne                          put: -1;
+		at: ODBMinusTwoCode                      put: -2;
+		at: ODBMinusOneCode                      put: -1;
 		at: ODBSmallStringBaseCode               put: ODBEmptyString;
 		at: ODBSmallStringBaseCode + 1           put: ODB1CharacterString;
 		at: ODBSmallStringBaseCode + 2           put: (ODBnCharacterString length: 2);
@@ -164,8 +164,8 @@ ODBTypeCodes class >> initializeTypeCodes [
 	ODBSmallPositiveIntegerBaseCode := 50. 
 	"50 .. 64 integers 0 .. 16"
 	ODBMinusThreeCode := 67.
-	ODBMinusTwo := 68.
-	ODBMinusOne := 69.
+	ODBMinusTwoCode := 68.
+	ODBMinusOneCode := 69.
 	"small strings of size small than 10 bytes are written with type 70 + size of string"
 	ODBSmallStringBaseCode := 70.
 	"70 .. 79 small strings"


### PR DESCRIPTION
- as a class variable, typeCodeMapping should be uppercase
- use  .. Code for ODBMinusTwo ODBMinusOne, as we have ODBMinusThreeCode already