### PR TITLE
[to discuss] 48-IntegerodbSerialize-Why-do-we-not-call-register-LargePositiveNegative-Integers

### DIFF
--- a/src/OmniBase-Tests/ODBSerializationTest.class.st
+++ b/src/OmniBase-Tests/ODBSerializationTest.class.st
@@ -401,7 +401,7 @@ ODBSerializationTest >> testSerializationLargeInteger [
 	
 	object := SmallInteger maxVal + 1.
 	serialized := ODBSerializer serializeToBytes: object.
-	self assert: serialized equals: #[0 0 0 0 0 0 11 128 128 128 128 128 128 128 128 16].
+	self assert: serialized equals: #[0 0 1 0 0 0 11 128 128 128 128 128 128 128 128 16].
 	self assert: (serialized at: 7) equals: ODBLargePositiveIntegerCode.
 
 	materialized := ODBDeserializer deserializeFromBytes: serialized.
@@ -410,7 +410,7 @@ ODBSerializationTest >> testSerializationLargeInteger [
 	"Negative"
 	object := SmallInteger minVal - 1.
 	serialized := ODBSerializer serializeToBytes: object.
-	self assert: serialized equals: #[0 0 0 0 0 0 12 129 128 128 128 128 128 128 128 16].
+	self assert: serialized equals: #[0 0 1 0 0 0 12 129 128 128 128 128 128 128 128 16].
 		self assert: (serialized at: 7) equals: ODBLargeNegativeIntegerCode.
 
 	materialized := ODBDeserializer deserializeFromBytes: serialized.
@@ -432,8 +432,8 @@ ODBSerializationTest >> testSerializationLargeIntegerTwice [
 	self assert: (serialized at: 7) equals: ODBArrayCode.
 	"First LargeInteger"
 	self assert: (serialized at: 9) equals: ODBLargePositiveIntegerCode.
-	"Second LargeInteger. Should this be a reference?"
-	self assert: (serialized at: 19) equals: ODBLargePositiveIntegerCode.
+	"Second LargeInteger, reference to the first"
+	self assert: (serialized at: 19) equals: ODBInternalReferenceCode.
 	
 	materialized := ODBDeserializer deserializeFromBytes: serialized.
 	self assert: object first identicalTo: object second.
@@ -454,6 +454,8 @@ ODBSerializationTest >> testSerializationLargeIntegerTwice [
 	materialized := ODBDeserializer deserializeFromBytes: serialized.
 	self assert: object first identicalTo: object second.
 	self assert: materialized equals: object.
+	"identity is preserved"
+	self assert: materialized first identicalTo: materialized second.
 	
 ]
 

--- a/src/OmniBase/Integer.extension.st
+++ b/src/OmniBase/Integer.extension.st
@@ -32,7 +32,7 @@ Integer >> odbBasicSerialize: serializer [
 
 { #category : #'*omnibase' }
 Integer >> odbSerialize: serializer [
-	"Small Integers are immediate object, no registration needed"
-	self flag: #TODO. "Explain why we do not register Large Integers?"
+	"Small Integers are immediate objects, no registration needed"
+	self isLarge ifTrue: [ (serializer register: self) ifTrue: [^self] ].
 	self odbBasicSerialize: serializer
 ]

--- a/src/OmniBase/ODBEncodingStream.class.st
+++ b/src/OmniBase/ODBEncodingStream.class.st
@@ -164,12 +164,23 @@ ODBEncodingStream >> nextFraction: aClass [
 
 { #category : #reading }
 ODBEncodingStream >> nextLargeNegativeInteger [
-	^ 0 - stream getPositiveInteger
+	| integer |
+	"Large Integers are normal objects (need to be registered), small integers are immediate"
+	integer := 0 - stream getPositiveInteger.
+	^ integer isLarge
+		  ifTrue: [ readerWriter register: integer ]
+		  ifFalse: [ integer ]
 ]
 
 { #category : #reading }
 ODBEncodingStream >> nextLargePositiveInteger [
-	^ stream getPositiveInteger
+
+	| integer |
+	"Large Integers are normal objects (need to be registered), small integers are immediate"
+	integer := stream getPositiveInteger.
+	^ integer isLarge
+		  ifTrue: [ readerWriter register: integer ]
+		  ifFalse: [ integer ]
 ]
 
 { #category : #reading }


### PR DESCRIPTION
This PR makes sure that we register Large Integers (not large in the database sense, but large in the sense of the being instances of LargePositiveInteger or LargeNegativeInteger).

These are "normal" objects, and if we store them, we should store the second one as an internal reference. This way, identity is preserved and we save disk space to store these just once.

fixes #148