### PR TITLE
124-File-locking-errors-on-mac-ARM--Im-not-sure-why

### DIFF
--- a/src/OmniBase/BSDFLock.class.st
+++ b/src/OmniBase/BSDFLock.class.st
@@ -41,18 +41,19 @@ BSDFLock class >> canLock: fileHandle from: start to: length exclusive: exclusiv
 
 { #category : #private }
 BSDFLock class >> fcntl: fd command: cmd struct: struct [
-
 	^ self 
-		ffiCall: #(int fcntl(int fd, int cmd, FLock *struct))
-		module: LibC
+		ffiCall: #(int fcntl(int fd, int cmd, FLock *struct)) 
+		library: LibC
+		fixedArgumentCount:2
 ]
 
 { #category : #private }
 BSDFLock class >> fcntl: fd command: cmd value: value [
 
 	^ self 
-		ffiCall: #(int fcntl(int fd, int cmd, int value))
-		module: LibC
+		ffiCall: #(int fcntl(int fd, int cmd, ulong value))
+		library: LibC
+		fixedArgumentCount:2
 ]
 
 { #category : #'field definition' }


### PR DESCRIPTION
That took a while... but I found it: on the M1 it is important to use the "fixedArgumentCount:" variation when calling variadic arguments, so that the right calling convention can be used

fcntl: fd command: cmd struct: struct
	^ self 
		ffiCall: #(int fcntl(int fd, int cmd, FLock *struct)) 
		library: LibC
		fixedArgumentCount:2