### PR TITLE
Fix wide symbol

### DIFF
--- a/src/OmniBase-Tests/ODBSerializationTest.class.st
+++ b/src/OmniBase-Tests/ODBSerializationTest.class.st
@@ -1019,6 +1019,27 @@ ODBSerializationTest >> testSerializationWideStringUTF8 [
 	self assert: materialized equals: string.
 ]
 
+{ #category : #tests }
+ODBSerializationTest >> testSerializationWideSymbol [
+	| symbol serialized materialized |
+	symbol := String
+		with: 16rF600 asCharacter
+		with: 16rF603 asCharacter
+		with: 16r0155 asCharacter
+		with: 16r0111 asCharacter.
+	symbol := symbol asSymbol.
+	self assert: symbol isWideString.
+	
+	ODBEncodingStream characterEncoding: #utf8.
+	
+	serialized := ODBSerializer serializeToBytes: symbol.
+	self assert: serialized equals: #[0 0 0 0 0 0 48 10 239 152 128 239 152 131 197 149 196 145].
+	self assert: (serialized at: 7) equals: ODBWideSymbolCode.
+	
+	materialized := ODBDeserializer deserializeFromBytes: serialized.
+	self assert: materialized equals: symbol
+]
+
 { #category : #'tests-layouts' }
 ODBSerializationTest >> testSerializationWordLayout [
 	| object serialized materialized |

--- a/src/OmniBase/BSDFLock.class.st
+++ b/src/OmniBase/BSDFLock.class.st
@@ -44,7 +44,7 @@ BSDFLock class >> fcntl: fd command: cmd struct: struct [
 	^ self 
 		ffiCall: #(int fcntl(int fd, int cmd, FLock *struct)) 
 		library: LibC
-		fixedArgumentCount:2
+		fixedArgumentCount: 2
 ]
 
 { #category : #private }
@@ -53,7 +53,7 @@ BSDFLock class >> fcntl: fd command: cmd value: value [
 	^ self 
 		ffiCall: #(int fcntl(int fd, int cmd, ulong value))
 		library: LibC
-		fixedArgumentCount:2
+		fixedArgumentCount: 2
 ]
 
 { #category : #'field definition' }

--- a/src/OmniBase/BSDFLock.class.st
+++ b/src/OmniBase/BSDFLock.class.st
@@ -41,18 +41,19 @@ BSDFLock class >> canLock: fileHandle from: start to: length exclusive: exclusiv
 
 { #category : #private }
 BSDFLock class >> fcntl: fd command: cmd struct: struct [
-
 	^ self 
-		ffiCall: #(int fcntl(int fd, int cmd, FLock *struct))
-		module: LibC
+		ffiCall: #(int fcntl(int fd, int cmd, FLock *struct)) 
+		library: LibC
+		fixedArgumentCount:2
 ]
 
 { #category : #private }
 BSDFLock class >> fcntl: fd command: cmd value: value [
 
 	^ self 
-		ffiCall: #(int fcntl(int fd, int cmd, int value))
-		module: LibC
+		ffiCall: #(int fcntl(int fd, int cmd, ulong value))
+		library: LibC
+		fixedArgumentCount:2
 ]
 
 { #category : #'field definition' }

--- a/src/OmniBase/ByteSymbol.extension.st
+++ b/src/OmniBase/ByteSymbol.extension.st
@@ -1,19 +1,19 @@
-Extension { #name : #Symbol }
+Extension { #name : #ByteSymbol }
 
 { #category : #'*omnibase' }
-Symbol >> odbBasicSerialize: serializer [
+ByteSymbol >> odbBasicSerialize: serializer [
 
 	serializer stream nextPutSymbol: self
 ]
 
 { #category : #'*omnibase' }
-Symbol class >> odbDeserialize: deserializer [
+ByteSymbol class >> odbDeserialize: deserializer [
 
 	^ deserializer stream nextSymbol
 ]
 
 { #category : #'*omnibase' }
-Symbol >> odbSerialize: serializer [
+ByteSymbol >> odbSerialize: serializer [
 	"Symbols are created by #asSymbol, thus we do not care that we store them multiple times,
 	if the Symbol is larger than an inernal reference, we might waste space (most symbols are small)"
 	

--- a/src/OmniBase/FLock.class.st
+++ b/src/OmniBase/FLock.class.st
@@ -48,7 +48,8 @@ FLock class >> fcntl: fd command: cmd struct: struct [
 
 	^ self 
 		ffiCall: #(int fcntl(int fd, int cmd, FLock *struct))
-		module: LibC
+		library: LibC
+		fixedArgumentCount: 2
 ]
 
 { #category : #private }
@@ -56,7 +57,8 @@ FLock class >> fcntl: fd command: cmd value: value [
 
 	^ self 
 		ffiCall: #(int fcntl(int fd, int cmd, int value))
-		module: LibC
+		library: LibC
+		fixedArgumentCount: 2
 ]
 
 { #category : #'field definition' }

--- a/src/OmniBase/ODBEncodingStream.class.st
+++ b/src/OmniBase/ODBEncodingStream.class.st
@@ -459,6 +459,16 @@ ODBEncodingStream >> nextPutWideString: aWideString [
 		putBytesFrom: buf len: buf size
 ]
 
+{ #category : #writing }
+ODBEncodingStream >> nextPutWideSymbol: aSymbol [ 
+	| buf |
+	buf := self class encodeString: aSymbol asString.
+	stream
+		putByte: ODBWideSymbolCode;
+		putPositiveInteger: buf size;
+		putBytesFrom: buf len: buf size
+]
+
 { #category : #reading }
 ODBEncodingStream >> nextSmallFloat64: aDeserializer [ 
 	"We multiply the Boxesfloat by 1, this way we create a SmallFloat if possible"
@@ -496,6 +506,14 @@ ODBEncodingStream >> nextWideString [
 	buf := ByteArray new: (len := stream getPositiveInteger).
 	stream getBytesFor: buf len: len.
 	^ readerWriter register: (self class decodeBytes: buf)
+]
+
+{ #category : #reading }
+ODBEncodingStream >> nextWideSymbol [
+	| buf len |
+	buf := ByteArray new: (len := stream getPositiveInteger).
+	stream getBytesFor: buf len: len.
+	^ (self class decodeBytes: buf) asSymbol
 ]
 
 { #category : #reading }

--- a/src/OmniBase/ODBTypeCodes.class.st
+++ b/src/OmniBase/ODBTypeCodes.class.st
@@ -39,6 +39,7 @@ Class {
 		'ODBTrueCode',
 		'ODBUndefinedObjectCode',
 		'ODBWideStringCode',
+		'ODBWideSymbolCode',
 		'TypeCodeMapping'
 	],
 	#category : #'OmniBase-Base'
@@ -68,7 +69,8 @@ ODBTypeCodes class >> initializeTypeCodeMapping [
 		at: ODBTrueCode                          put: true;
 		at: ODBFalseCode                         put: false;
 		at: ODBMessageCode                       put: Message;
-		at: ODBSymbolCode                        put: Symbol;
+		at: ODBSymbolCode                        put: ByteSymbol;
+		at: ODBWideSymbolCode 						 put: WideSymbol;
 		at: ODBSystemDictionaryCode              put: Smalltalk globals;
 		at: ODBMessageSendCode                   put: MessageSend;
 		at: ODBProcessSchedulerCode              put: Processor;
@@ -160,6 +162,7 @@ ODBTypeCodes class >> initializeTypeCodes [
 	ODBFloatCode := 40.
 	ODBScaledDecimalCode := 45.
 	ODBSmallFloat64Code := 47.
+	ODBWideSymbolCode := 48.
 	"integers <= 16 are stored with code 50 + number"
 	ODBSmallPositiveIntegerBaseCode := 50. 
 	"50 .. 64 integers 0 .. 16"

--- a/src/OmniBase/WideSymbol.extension.st
+++ b/src/OmniBase/WideSymbol.extension.st
@@ -5,3 +5,23 @@ WideSymbol >> asBtreeKeyOfSize: keySize [
 	"workaround to the missing #asByteArray, see pharo issue #11015"
 	^self asString asByteArray asBtreeKeyOfSize: keySize
 ]
+
+{ #category : #'*OmniBase' }
+WideSymbol >> odbBasicSerialize: serializer [
+
+	serializer stream nextPutWideSymbol: self
+]
+
+{ #category : #'*OmniBase' }
+WideSymbol class >> odbDeserialize: deserializer [
+
+	^ deserializer stream nextWideSymbol 
+]
+
+{ #category : #'*OmniBase' }
+WideSymbol >> odbSerialize: serializer [
+	"Symbols are created by #asSymbol, thus we do not care that we store them multiple times,
+	if the Symbol is larger than an inernal reference, we might waste space (most symbols are small)"
+	
+	self odbBasicSerialize: serializer
+]


### PR DESCRIPTION
This PR add a tests for wide symbol serialisation and fixes it.

I used the free code 48.

	ODBWideSymbolCode := 48.
	
fixes #119