### PR TITLE
186-ODBSerializercantSave-does-not-raise-error-serialises-error-string

### DIFF
--- a/src/OmniBase-Tests/ODBSerializationTest.class.st
+++ b/src/OmniBase-Tests/ODBSerializationTest.class.st
@@ -39,12 +39,10 @@ ODBSerializationTest >> testSerializationAssociation [
 
 { #category : #tests }
 ODBSerializationTest >> testSerializationBlockClosure [
-	| object serialized materialized |
+	| object serialized  |
 	object := [].
-	serialized := ODBSerializer serializeToBytes: object.
-	
-	materialized := ODBDeserializer deserializeFromBytes: serialized.
-	self assert: materialized equals: #'FullBlockClosure can''t be stored!'
+	"we do not uet support serializing closures"
+	self should: [serialized := ODBSerializer serializeToBytes: object] raise: TestResult error
 ]
 
 { #category : #tests }
@@ -548,12 +546,10 @@ ODBSerializationTest >> testSerializationOrderedCollection [
 
 { #category : #tests }
 ODBSerializationTest >> testSerializationProcess [
-	| object serialized materialized |
+	| object serialized |
 	object := Processor activeProcess.
-	serialized := ODBSerializer serializeToBytes: object.
-	
-	materialized := ODBDeserializer deserializeFromBytes: serialized.
-	self assert: materialized equals: #'Process can''t be stored!'
+	"we do not uet support serializing Processes"
+	self should: [serialized := ODBSerializer serializeToBytes: object] raise: TestResult error
 ]
 
 { #category : #tests }

--- a/src/OmniBase/ODBSerializer.class.st
+++ b/src/OmniBase/ODBSerializer.class.st
@@ -67,8 +67,8 @@ ODBSerializer >> addExternalReference: anObject objectId: anObjectId [
 ]
 
 { #category : #private }
-ODBSerializer >> cantSave: anObject [ 
-	anObject class name , ' can''t be stored!' odbSerialize: self
+ODBSerializer >> cantSave: anObject [
+	OmniBase signalError: anObject class name , ' can''t be stored!'
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
When storing BlockClosure and Process, we used to silently just serialize the error message.

Instead, we should raise an error when storing so bugs are not hidden.

fixes #186