### PR TITLE
156-CompiledMethodLayout-is-not-supported 

### DIFF
--- a/src/OmniBase-Tests/ODBSerializationTest.class.st
+++ b/src/OmniBase-Tests/ODBSerializationTest.class.st
@@ -227,9 +227,6 @@ ODBSerializationTest >> testSerializationClass [
 { #category : #'tests-layouts' }
 ODBSerializationTest >> testSerializationCompiledMethodLayout [
 	| object serialized materialized |
-	self skip.
-	"Not yet implemented"
-	self flag: #TODO.
 	"We use CompiledMethod as an exampe of a class with a CompiledMethodLayout"
 	object := (OrderedCollection>>#do:) copy.
 	
@@ -237,7 +234,27 @@ ODBSerializationTest >> testSerializationCompiledMethodLayout [
 	serialized := ODBSerializer serializeToBytes: object.
 
 	materialized := ODBDeserializer deserializeFromBytes: serialized.
+	
+	self assert: materialized bytecode equals: object bytecode.
+	self assert: materialized literals equals: object literals.
 	self assert: materialized equals: object.
+	self assert: materialized class classLayout class equals: CompiledMethodLayout.
+]
+
+{ #category : #'tests-layouts' }
+ODBSerializationTest >> testSerializationCompiledMethodLayout2 [
+	| object serialized materialized |
+	"This tests CompiledBlock. we use a clean block for now"
+	object := [1+2 "clean block"] compiledBlock.
+	
+	self assert: object class classLayout class equals: CompiledMethodLayout.
+	serialized := ODBSerializer serializeToBytes: object.
+
+	materialized := ODBDeserializer deserializeFromBytes: serialized.
+	
+	"for #= we need equal outercode to be the same, too"
+	self assert: materialized bytecode equals: object bytecode.
+	self assert: materialized literals equals: object literals.
 	self assert: materialized class classLayout class equals: CompiledMethodLayout.
 ]
 

--- a/src/OmniBase/CompiledBlock.extension.st
+++ b/src/OmniBase/CompiledBlock.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #CompiledBlock }
+
+{ #category : #'*OmniBase' }
+CompiledBlock >> odbBasicSerialize: serializer [
+
+	serializer stream nextPutCompiledBlock: self
+]
+
+{ #category : #'*OmniBase' }
+CompiledBlock class >> odbDeserialize: deserializer [
+
+	^ deserializer stream nextCompiledBlock: self
+]

--- a/src/OmniBase/CompiledMethod.extension.st
+++ b/src/OmniBase/CompiledMethod.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #CompiledMethod }
+
+{ #category : #'*OmniBase' }
+CompiledMethod >> odbBasicSerialize: serializer [
+
+	serializer stream nextPutCompiledMethod: self
+]
+
+{ #category : #'*OmniBase' }
+CompiledMethod class >> odbDeserialize: deserializer [
+
+	^ deserializer stream nextCompiledMethod: self
+]

--- a/src/OmniBase/ODBEncodingStream.class.st
+++ b/src/OmniBase/ODBEncodingStream.class.st
@@ -129,6 +129,58 @@ ODBEncodingStream >> nextClass [
 ]
 
 { #category : #reading }
+ODBEncodingStream >> nextCompiledBlock: aClass [
+
+	| header bytecodesSize compiledBlock |
+	
+	header := stream getInteger.
+	bytecodesSize := stream getInteger.
+	compiledBlock := aClass
+		newMethod: bytecodesSize
+		header: header.
+	
+	"first the literals"
+	"note: we store the outer method here as a copy, more thinking needed"
+	1 to: compiledBlock numLiterals   do: [:i | 
+				compiledBlock literalAt: i put: self odbNextObject ].			
+	
+	compiledBlock initialPC 
+		to: compiledBlock size
+		do: [ :index |
+			compiledBlock
+				at: index
+				put: stream getByte ].
+	^compiledBlock
+]
+
+{ #category : #reading }
+ODBEncodingStream >> nextCompiledMethod: aClass [
+
+	| header bytecodesPlusTrailerSize compiledMethod |
+	
+	header := stream getInteger.
+	bytecodesPlusTrailerSize := stream getInteger.
+	
+	compiledMethod := aClass
+		newMethod: bytecodesPlusTrailerSize
+		header: header.
+	
+	"first the literals"	
+	"for now we do store the class pointer in the last literal"	
+	1 to: compiledMethod numLiterals do: [:i | 
+				compiledMethod literalAt: i  put: self odbNextObject ].			
+	
+	"then the bytecodes, we ignore the trailer for now"
+	compiledMethod initialPC 
+		to: compiledMethod size - compiledMethod trailer size
+		do: [ :index |
+			compiledMethod
+				at: index
+				put: stream getByte ].
+	^compiledMethod
+]
+
+{ #category : #reading }
 ODBEncodingStream >> nextDate: aClass [
 	^ readerWriter register: (aClass 
 		odbDateFromSeconds: stream getInteger 
@@ -293,6 +345,45 @@ ODBEncodingStream >> nextPutClass: aClass [
 	stream 
 		putByte: ODBClassCode; 
 		putString: aClass name asString
+]
+
+{ #category : #writing }
+ODBEncodingStream >> nextPutCompiledBlock: aCompiledMethod [ 
+	| cmInitialPC bytecodesPlusTrailerSize |
+
+	cmInitialPC := aCompiledMethod initialPC.
+	bytecodesPlusTrailerSize := aCompiledMethod size - cmInitialPC + 1.
+	
+	stream 
+		putByte: ODBCompiledBlockCode;
+		putInteger: aCompiledMethod header;
+	 	putInteger: bytecodesPlusTrailerSize.
+	"literals"
+	"Here we have to take care about outer code: for now we will serialize it"
+	
+	1 to: aCompiledMethod numLiterals do: [:i | 
+				(aCompiledMethod literalAt: i) odbSerialize: readerWriter ].
+	"variable part"
+	stream putBytesFrom: aCompiledMethod bytecode len: aCompiledMethod size - aCompiledMethod initialPC + 1
+]
+
+{ #category : #writing }
+ODBEncodingStream >> nextPutCompiledMethod: aCompiledMethod [ 
+	| cmInitialPC bytecodesPlusTrailerSize |
+
+	cmInitialPC := aCompiledMethod initialPC.
+	bytecodesPlusTrailerSize := aCompiledMethod size - cmInitialPC + 1.
+	
+	stream 
+		putByte: ODBCompiledMethodCode;
+		putInteger: aCompiledMethod header;
+	 	putInteger: bytecodesPlusTrailerSize.
+	"literals"
+	"for now we do store the class pointer in the last literal"
+	1 to: aCompiledMethod numLiterals do: [:i | 
+				(aCompiledMethod literalAt: i) odbSerialize: readerWriter ].
+	"variable part"
+	stream putBytesFrom: aCompiledMethod bytecode len: aCompiledMethod size - aCompiledMethod initialPC
 ]
 
 { #category : #writing }

--- a/src/OmniBase/ODBTypeCodes.class.st
+++ b/src/OmniBase/ODBTypeCodes.class.st
@@ -7,6 +7,8 @@ Class {
 		'ODBByteArrayCode',
 		'ODBCharacterCode',
 		'ODBClassCode',
+		'ODBCompiledBlockCode',
+		'ODBCompiledMethodCode',
 		'ODBDateCode',
 		'ODBDictionaryCode',
 		'ODBDoubleByteCharacterCode',
@@ -75,6 +77,8 @@ ODBTypeCodes class >> initializeTypeCodeMapping [
 		at: ODBMessageSendCode                   put: MessageSend;
 		at: ODBProcessSchedulerCode              put: Processor;
 		at: ODBClassCode                         put: Class;
+		at: ODBCompiledMethodCode 					 put: CompiledMethod;
+		at: ODBCompiledBlockCode 					 put: CompiledBlock;
 		at: ODBDoubleByteCharacterCode           put: ODBDoubleByteCharacter;
 		at: ODBAssociationCode                   put: Association;
 		at: ODBDateCode                          put: Date;
@@ -147,7 +151,8 @@ ODBTypeCodes class >> initializeTypeCodes [
 	ODBProcessSchedulerCode := 22.
 	"23 .. 25"
 	ODBClassCode := 26.
-	"27 .. 28"
+	ODBCompiledMethodCode := 27.
+	ODBCompiledBlockCode := 28.
 	ODBDoubleByteCharacterCode := 29.
 	"30"
 	ODBAssociationCode := 31.


### PR DESCRIPTION
This is a first version that implements storing CompiledMethod and CompiledBlock

Note:
- CompiledMethod Trailer is for now ignored
- We do store the last literal for now
	- this stores a copy of the outer method for blocks
	- the class for Compiledmethod

More work is needed. We need to somehow late-bind the class and the outer method and fill the correct ones on de-serialization.

Fixes #156