### PR TITLE
 Simplify Integer Serialisation

### DIFF
--- a/src/OmniBase/Integer.extension.st
+++ b/src/OmniBase/Integer.extension.st
@@ -29,10 +29,3 @@ Integer >> odbBasicSerialize: serializer [
 
 	serializer stream nextPutInteger: self
 ]
-
-{ #category : #'*omnibase' }
-Integer >> odbSerialize: serializer [
-	"Small Integers are immediate objects, no registration needed"
-	self isLarge ifTrue: [ (serializer register: self) ifTrue: [^self] ].
-	self odbBasicSerialize: serializer
-]

--- a/src/OmniBase/ODBEncodingStream.class.st
+++ b/src/OmniBase/ODBEncodingStream.class.st
@@ -167,9 +167,9 @@ ODBEncodingStream >> nextLargeNegativeInteger [
 	| integer |
 	"Large Integers are normal objects (need to be registered), small integers are immediate"
 	integer := 0 - stream getPositiveInteger.
-	^ integer isLarge
-		  ifTrue: [ readerWriter register: integer ]
-		  ifFalse: [ integer ]
+	^ integer isImmediateObject
+		  ifFalse: [ readerWriter register: integer ]
+		  ifTrue: [ integer ]
 ]
 
 { #category : #reading }
@@ -178,9 +178,9 @@ ODBEncodingStream >> nextLargePositiveInteger [
 	| integer |
 	"Large Integers are normal objects (need to be registered), small integers are immediate"
 	integer := stream getPositiveInteger.
-	^ integer isLarge
-		  ifTrue: [ readerWriter register: integer ]
-		  ifFalse: [ integer ]
+	^ integer isImmediateObject
+		  ifFalse: [ readerWriter register: integer ]
+		  ifTrue: [ integer ]
 ]
 
 { #category : #reading }

--- a/src/OmniBase/SmallInteger.extension.st
+++ b/src/OmniBase/SmallInteger.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #SmallInteger }
+
+{ #category : #'*OmniBase' }
+SmallInteger >> odbSerialize: serializer [
+	"Small Integers are immediate objects, no registration needed"
+	self odbBasicSerialize: serializer
+]


### PR DESCRIPTION
Instead of an if in odbSerialize: of Integer,  re-implement it in SmallInteger to not register.

Do not use #isLarge, but isImmediateObject in the read code, to be in sync with the comment