### PR TITLE
 Test-and-Fix-isODBPersistent

### DIFF
--- a/src/OmniBase-Tests/ODBDatabaseTest.class.st
+++ b/src/OmniBase-Tests/ODBDatabaseTest.class.st
@@ -120,6 +120,20 @@ ODBDatabaseTest >> testIsChanged [
 ]
 
 { #category : #tests }
+ODBDatabaseTest >> testIsODBPersistent [
+
+	[ 
+	| collection |
+	collection := OrderedCollection newPersistent
+		add: 'string object';
+		yourself.
+		self assert: collection isODBPersistent.
+	 ] evaluateAndCommitIn: db newTransaction.
+	
+
+]
+
+{ #category : #tests }
 ODBDatabaseTest >> testIsPersistent [ 
 	| txn obj |
 	txn := db newTransaction.

--- a/src/OmniBase/Object.extension.st
+++ b/src/OmniBase/Object.extension.st
@@ -43,7 +43,7 @@ Object >> isODBExpired [
 { #category : #'*omnibase' }
 Object >> isODBPersistent [
 
-	^ self currentTransaction isPersistent: self
+	^ OmniBase currentTransaction isPersistent: self
 ]
 
 { #category : #'*omnibase' }


### PR DESCRIPTION
Object>>#isODBPersistent send the message #currentTransaction which does not exist on Object

- use OmniBase currentTransaction instead
- add test